### PR TITLE
Usability improvements

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,3 +2,4 @@ include etc/*
 include testdata/*
 include gapfilled_tles/*
 include pygac/*.pyx
+include bin/pygac-*

--- a/bin/pygac-run
+++ b/bin/pygac-run
@@ -1,4 +1,3 @@
-
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 

--- a/doc/source/api.rst
+++ b/doc/source/api.rst
@@ -3,7 +3,7 @@ The :mod:`pygac` API
 
 *pygac* interface consists of a number of python modules. The following schematic shows a general structure and the processing flow of *pygac*.   
 
-It must be noted that *pygac* expects Level 1b file to contain normal GAC header and data records, the format of which are mentioned in the official NOAA POD and KLM Data User Guides. The user should not prepend any other header (e.g. when downloading GAC data from CLASS archive etc) to the L1b file. In the first pre-processing step, *pygac* determines whether the GAC data comes from the second (i.e. NOAA-14 and before) or the third generation (NOAA-15 and onwards) AVHRR instrument by "gac_run.py".
+It must be noted that *pygac* expects Level 1b file to contain normal GAC header and data records, the format of which are mentioned in the official NOAA POD and KLM Data User Guides. The user should not prepend any other header (e.g. when downloading GAC data from CLASS archive etc) to the L1b file. In the first pre-processing step, *pygac* determines whether the GAC data comes from the second (i.e. NOAA-14 and before) or the third generation (NOAA-15 and onwards) AVHRR instrument by "pygac-run".
 This is done by reading the first three bytes of the data set. If they contain the any of the following values, ["CMS", "NSS", "UKM", "DSS"], then the KLM reader from "gac_klm.py" file is invoked, otherwise the POD reader is invoked (gac_pod.py).
 
 

--- a/doc/source/installation.rst
+++ b/doc/source/installation.rst
@@ -6,20 +6,41 @@ the art calibration and navigation.
 
 You can install the latest stable release of the software via the python package index (pypi)::
 
-  $> pip install pygac
+  $> pip install --prefix=$PREFIX pygac
 
-If you want access to the full source code and/or test the latest version under
-development you can download the pygac source code from github_::
+where ``$PREFIX`` denotes your desired installation prefix. If you want access to the full 
+source code and/or test the latest version under development you can download the pygac 
+source code from github_::
 
   $> git clone git://github.com/pytroll/pygac.git
+  $> cd pygac
 
 and then run::
 
-  $> python setup.py install
+  $> pip install --prefix=$PREFIX .
 
 or, if you want to hack the package::
 
-  $> python setup.py develop
+  $> pip install -e --prefix=$PREFIX .
+
+To uninstall the package run::
+
+  $> pip uninstall pygac
+
+
+At runtime
+----------
+
+Let $PREFIX be the prefix of your pygac installation. To make the python 
+interpreter aware of the pygac module, update the ``$PYTHONPATH`` environment
+variable::
+
+  $> export PYTHONPATH=$PREFIX/lib/python2.7/site-packages:$PYTHONPATH
+
+Furthermore, update the ``$PATH`` environment variable to have the pygac 
+scripts available in your session::
+
+  $> export PATH=$PREFIX/bin:$PATH
 
 
 .. _github: http://github.com/pytroll/pygac

--- a/doc/source/usage.rst
+++ b/doc/source/usage.rst
@@ -10,7 +10,7 @@ pointing to the file. E.g.::
 Also adapt the configuration file to your needs. The ``tledir`` parameter should
 be set to where your Two Line Element (TLE) files are located.
 
-The main script is ``gac_run.py``. It automatically checks for the type of file
+The main script is ``pygac-run``. It automatically checks for the type of file
 format and invokes either ``gac_pod.py`` (POD family, up to and including NOAA-14)
 or ``gac_klm.py`` (KLM family, NOAA-15 and onwards including Metop-A and -B).
 
@@ -19,11 +19,10 @@ will be three hdf5 files, one with the calibrated AVHRR data, the other with
 sun-satellite viewing geometry data and this third with scanline quality
 information::
 
- $> python pygac/gac_run.py testdata/NSS.GHRR.NL.D02187.S1904.E2058.B0921517.GC 0 0
+ $> pygac-run testdata/NSS.GHRR.NL.D02187.S1904.E2058.B0921517.GC 0 0
  
 The last two digits are the start and end scanline numbers, thus specifying the
 portion of the GAC orbit that user wants to process.  The first scanline number
 starts at 0. If zeroes are specified at both locations, then the entire orbit
 will be processed.
-
 

--- a/setup.py
+++ b/setup.py
@@ -103,7 +103,7 @@ if __name__ == '__main__':
                             'scipy'],
           extras_require={'geolocation interpolation': ['python-geotiepoints'],
                           },
-          scripts=[],
+          scripts=[os.path.join('bin', item) for item in os.listdir('bin')],
           data_files=[('etc', ['etc/pygac.cfg.template']),
                       ('gapfilled_tles', ['gapfilled_tles/TLE_noaa16.txt'])],
           test_suite="pygac.tests.suite",


### PR DESCRIPTION
- Install scripts to the standard location $PREFIX/bin
- Proposed naming convention for scripts: pygac-script-name
- Use pip to install the package from source as it is much more reliable for installing dependencies

Anyway, this is just a proposal, feel free to edit/reject.