### PR TITLE
Fix selection of user defined scanlines #2

### DIFF
--- a/pygac/gac_io.py
+++ b/pygac/gac_io.py
@@ -204,8 +204,11 @@ def save_gac(satellite_name,
     # Update midnight scanline to the final scanline range
     if midnight_scanline is not None:
         midnight_scanline -= (temp_start_line + start_line)
-    if midnight_scanline < 0:
-        # Midnight scanline Has been removed
+
+    # Set midnight scanline to None if it has been removed due to invalid
+    # lat/lon info (< 0) or lies outside the user defined scanline range
+    if midnight_scanline < 0 or (midnight_scanline > end_line or
+                                 midnight_scanline < start_line):
         midnight_scanline = None
 
     # Compute total number of scanlines

--- a/pygac/gac_io.py
+++ b/pygac/gac_io.py
@@ -68,6 +68,18 @@ MISSING_DATA = -32001
 MISSING_DATA_LATLON =  -999999
 
 
+def update_start_end_line(start_line, end_line, temp_start_line, temp_end_line):
+    """Update user start/end lines after data has been sliced using temporary
+    start/end lines.
+
+    Returns:
+        Updated start_line, updated end_line
+    """
+    new_start_line = max(0, start_line - temp_start_line)
+    new_end_line = min(end_line, temp_end_line) - temp_start_line
+    return new_start_line, new_end_line
+
+
 def save_gac(satellite_name,
              xutcs,
              lats, lons,
@@ -77,10 +89,17 @@ def save_gac(satellite_name,
              mask, qual_flags, start_line, end_line, tsmcorr,
              gac_file, midnight_scanline, miss_lines, switch=None):
 
- 
+    along_track = lats.shape[0]
+    last_scan_line_number = qual_flags[-1, 0]
+
+    # Determine scanline range requested by user
     start_line = int(start_line)
     end_line = int(end_line)
+    if end_line == 0:
+        # If the user specifies 0 as the last scanline, process all scanlines
+        end_line = along_track
 
+    # Mask invalid data
     bt3 = np.where(np.logical_or(bt3<170.0, bt3>350.0), MISSING_DATA, bt3-273.15) 
     bt4 = np.where(np.logical_or(bt4<170.0, bt4>350.0), MISSING_DATA, bt4-273.15) 
     bt5 = np.where(np.logical_or(bt5<170.0, bt5>350.0), MISSING_DATA, bt5-273.15) 
@@ -112,21 +131,19 @@ def save_gac(satellite_name,
         ref3[switch == 2] = MISSING_DATA
         bt3[switch == 2] = MISSING_DATA
 
+    for array in [ref1, ref2, ref3, bt3, bt4, bt5]:
+        array[np.isnan(array)] = MISSING_DATA
 
+    # Choose new temporary start/end lines if lat/lon info is invalid
     no_wrong_lat = np.where(lats!=MISSING_DATA_LATLON)	
     temp_start_line = min(no_wrong_lat[0]) 
     temp_end_line = max(no_wrong_lat[0])
-
-
-    if temp_start_line>0 or temp_start_line>start_line:
+    if temp_start_line > start_line:
        LOG.info('New start_line chosen (due to invalid lat/lon info) = ' + str(temp_start_line))
-    if temp_end_line < lats.shape[0] or (end_line == 0 and temp_end_line < lats.shape[0]):
-       LOG.info('New temporary end_line chosen (due to invalid lat/lon info) = ' + str(temp_end_line))
-    if end_line>temp_end_line:
-       end_line = temp_end_line
+    if end_line > temp_end_line:
        LOG.info('New end_line chosen (due to invalid lat/lon info) = ' + str(temp_end_line))
 
-  
+    # Slice data using temporary start/end lines
     ref1 = ref1[temp_start_line:temp_end_line+1,:].copy()
     ref2 = ref2[temp_start_line:temp_end_line+1,:].copy()
     ref3 = ref3[temp_start_line:temp_end_line+1,:].copy()
@@ -140,17 +157,24 @@ def save_gac(satellite_name,
     rel_azi = rel_azi[temp_start_line:temp_end_line+1,:].copy()
     lats = lats[temp_start_line:temp_end_line+1,:].copy()
     lons = lons[temp_start_line:temp_end_line+1,:].copy()
+    miss_lines = np.array(
+        qual_flags[0:temp_start_line, 0].tolist() +
+        miss_lines.tolist() +
+        qual_flags[temp_end_line+1:, 0].tolist()
+    )
     qual_flags = qual_flags[temp_start_line:temp_end_line+1,:].copy()
     xutcs = xutcs[temp_start_line:temp_end_line+1].copy()
 
+    # Update user start/end lines to the new slice
+    start_line, end_line = update_start_end_line(
+        start_line=start_line,
+        end_line=end_line,
+        temp_start_line=temp_start_line,
+        temp_end_line=temp_end_line)
+
     # Reading time from the body of the gac file
     start = xutcs[start_line].astype(datetime.datetime)
-    if end_line == 0:
-        end = xutcs[-1].astype(datetime.datetime)
-    else:
-        end = xutcs[end_line].astype(datetime.datetime)
-
-
+    end = xutcs[end_line].astype(datetime.datetime)
     startdate = start.strftime("%Y%m%d")
     starttime = start.strftime("%H%M%S%f")[:-5]
     enddate = end.strftime("%Y%m%d")
@@ -160,30 +184,28 @@ def save_gac(satellite_name,
     # Earth-Sun distance correction factor
     corr = 1.0 - 0.0334 * np.cos(2.0 * np.pi * (jday - 2) / 365.25)
 
-   
-    total_number_of_scan_lines = end_line - start_line + 1 
-    last_scan_line_number = qual_flags[-1,0]
+    # Slice scanline range requested by user
+    ref1 = ref1[start_line:end_line+1,:].copy()
+    ref2 = ref2[start_line:end_line+1,:].copy()
+    ref3 = ref3[start_line:end_line+1,:].copy()
+    bt3 = bt3[start_line:end_line+1,:].copy()
+    bt4 = bt4[start_line:end_line+1,:].copy()
+    bt5 = bt5[start_line:end_line+1,:].copy()
+    sun_zen = sun_zen[start_line:end_line+1,:].copy()
+    sun_azi = sun_azi[start_line:end_line+1,:].copy()
+    sat_zen = sat_zen[start_line:end_line+1,:].copy()
+    sat_azi = sat_azi[start_line:end_line+1,:].copy()
+    rel_azi = rel_azi[start_line:end_line+1,:].copy()
+    lats = lats[start_line:end_line+1,:].copy()
+    lons = lons[start_line:end_line+1,:].copy()
+    qual_flags = qual_flags[start_line:end_line+1,:].copy()
 
+    # Update midnight scanline to the final scanline range
+    if midnight_scanline is not None:
+        midnight_scanline -= (temp_start_line + start_line)
 
-    if end_line>0:
-       ref1 = ref1[start_line:end_line+1,:].copy()
-       ref2 = ref2[start_line:end_line+1,:].copy()
-       ref3 = ref3[start_line:end_line+1,:].copy()
-       bt3 = bt3[start_line:end_line+1,:].copy()
-       bt4 = bt4[start_line:end_line+1,:].copy()
-       bt5 = bt5[start_line:end_line+1,:].copy()
-       sun_zen = sun_zen[start_line:end_line+1,:].copy()
-       sun_azi = sun_azi[start_line:end_line+1,:].copy()
-       sat_zen = sat_zen[start_line:end_line+1,:].copy()
-       sat_azi = sat_azi[start_line:end_line+1,:].copy()
-       rel_azi = rel_azi[start_line:end_line+1,:].copy()
-       lats = lats[start_line:end_line+1,:].copy()
-       lons = lons[start_line:end_line+1,:].copy()
-       qual_flags = qual_flags[start_line:end_line+1,:].copy()
-       xutcs = xutcs[start_line:end_line+1].copy()
-
-    for array in [ref1, ref2, ref3, bt3, bt4, bt5]:
-        array[np.isnan(array)] = MISSING_DATA
+    # Compute total number of scanlines
+    total_number_of_scan_lines = end_line - start_line + 1
 
     # Correct for temporary scan motor issue.
     #

--- a/pygac/gac_io.py
+++ b/pygac/gac_io.py
@@ -199,6 +199,7 @@ def save_gac(satellite_name,
     lats = lats[start_line:end_line+1,:].copy()
     lons = lons[start_line:end_line+1,:].copy()
     qual_flags = qual_flags[start_line:end_line+1,:].copy()
+    xutcs = xutcs[start_line:end_line+1].copy()
 
     # Update midnight scanline to the final scanline range
     if midnight_scanline is not None:

--- a/pygac/gac_io.py
+++ b/pygac/gac_io.py
@@ -203,6 +203,9 @@ def save_gac(satellite_name,
     # Update midnight scanline to the final scanline range
     if midnight_scanline is not None:
         midnight_scanline -= (temp_start_line + start_line)
+    if midnight_scanline < 0:
+        # Midnight scanline Has been removed
+        midnight_scanline = None
 
     # Compute total number of scanlines
     total_number_of_scan_lines = end_line - start_line + 1

--- a/pygac/gac_io.py
+++ b/pygac/gac_io.py
@@ -157,11 +157,11 @@ def save_gac(satellite_name,
     rel_azi = rel_azi[temp_start_line:temp_end_line+1,:].copy()
     lats = lats[temp_start_line:temp_end_line+1,:].copy()
     lons = lons[temp_start_line:temp_end_line+1,:].copy()
-    miss_lines = np.array(
+    miss_lines = np.sort(np.array(
         qual_flags[0:temp_start_line, 0].tolist() +
         miss_lines.tolist() +
         qual_flags[temp_end_line+1:, 0].tolist()
-    )
+    ))
     qual_flags = qual_flags[temp_start_line:temp_end_line+1,:].copy()
     xutcs = xutcs[temp_start_line:temp_end_line+1].copy()
 

--- a/pygac/gac_reader.py
+++ b/pygac/gac_reader.py
@@ -648,21 +648,23 @@ class GACReader(object):
             return False
 
     def get_midnight_scanline(self):
-        """Find the scanline where the UTC date switches (if any).
+        """Find the scanline where the UTC date increases by one day.
 
         Returns:
-            int: The midnight scanline if it exists. None, else.
+            int: The midnight scanline if it exists and is unique.
+                 None, else.
         """
         self.get_times()
-        days = (self.utcs.astype('datetime64[D]') - self.utcs.astype('datetime64[M]') + 1).astype(int)
-        jump_pos = np.where(np.diff(days) == 1)[0]
-        if len(jump_pos) == 0:
+        d0 = np.datetime64(datetime.date(1970, 1, 1), 'D')
+        days = (self.utcs.astype('datetime64[D]') - d0).astype(int)
+        incr = np.where(np.diff(days) == 1)[0]
+        if len(incr) != 1:
+            if len(incr) > 1:
+                LOG.warning('Unable to determine midnight scanline: '
+                            'UTC date increases more than once. ')
             return None
         else:
-            if len(jump_pos) > 1:
-                LOG.warning('UTC date switches more than once. Choosing the '
-                            'first occurence as midnight scanline.')
-            return jump_pos[0]
+            return incr[0]
 
     def get_miss_lines(self):
         """Find missing scanlines, i.e. scanlines which were dropped for some

--- a/pygac/tests/__init__.py
+++ b/pygac/tests/__init__.py
@@ -24,7 +24,7 @@
 """
 
 from pygac.tests import test_calibrate_pod, test_slerp, test_calibrate_klm, \
-    test_pod, test_corrections, test_reader
+    test_pod, test_corrections, test_reader, test_io
 import unittest
 
 
@@ -33,7 +33,7 @@ def suite():
     """
     mysuite = unittest.TestSuite()
     tests = (test_slerp, test_calibrate_klm, test_calibrate_pod,
-             test_pod, test_corrections, test_reader)
+             test_pod, test_corrections, test_reader, test_io)
     for test in tests:
         mysuite.addTests(test.suite())
 

--- a/pygac/tests/test_io.py
+++ b/pygac/tests/test_io.py
@@ -1,0 +1,195 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+# Author(s):
+
+#   Stephan Finkensieper <stephan.finkensieper@dwd.de>
+
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import unittest
+import numpy as np
+from pygac.gac_io import update_start_end_line
+
+
+class TestIO(unittest.TestCase):
+    """Test the gac_io module"""
+
+    longMessage = True
+
+    def test_update_start_end(self):
+        x = np.arange(0, 20)
+        start_line = 5
+        end_line = 15
+
+        for temp_start_line in (0, start_line, start_line + 1):
+            for temp_end_line in (x.size, end_line, end_line - 1):
+                where = 'temporary start/end lines {0}/{1}'.format(
+                    temp_start_line, temp_end_line)
+
+                # Define reference
+                if temp_start_line > start_line:
+                    ref_start = temp_start_line
+                else:
+                    ref_start = start_line
+                if temp_end_line < end_line:
+                    ref_end = temp_end_line
+                else:
+                    ref_end = end_line
+                ref = np.arange(ref_start, ref_end + 1)
+
+                # Compute new start & end line
+                new_start_line, new_end_line = update_start_end_line(
+                    start_line=start_line,
+                    end_line=end_line,
+                    temp_start_line=temp_start_line,
+                    temp_end_line=temp_end_line)
+
+                # Slice twice (as in gac_io)
+                slice1 = x[temp_start_line:temp_end_line + 1].copy()
+                self.assertGreaterEqual(
+                    new_start_line, 0,
+                    msg='Start line out of bounds for ' + where)
+                self.assertLessEqual(
+                    new_end_line, slice1.size,
+                    msg='End line out of bounds for ' + where)
+                slice2 = slice1[new_start_line:new_end_line + 1]
+
+                # Check results
+                self.assertTrue(np.all(ref == slice2),
+                                msg='Incorrect slice for ' + where)
+
+    def test_save_gac(self):
+        import pygac.gac_io
+
+        # Define test data
+        fv = pygac.gac_io.MISSING_DATA_LATLON
+        along = 10
+        across = 3
+        lats = np.arange(along*across).reshape((along, across))
+        lats[:2+1, :] = fv  # Make first 3 lines invalid
+        lats[7:, :] = fv  # Make last 3 lines invalid
+        lons = lats.copy()
+        xutcs = np.arange(along).astype('datetime64[ms]')
+        qualflags = np.array(
+            [[2, 3, 4, 6, 7, 8, 9, 10, 12, 13]]).transpose()  # scanline number
+        miss_lines = np.array([1, 5, 11, 14])
+        midnight_scanline = 5
+        dummydata = np.ones(lats.shape)
+
+        for start_line in (0, 1, 4):
+            for end_line in (9, 8, 5):
+                where = 'with start/end line {0}/{1}'.format(start_line,
+                                                             end_line)
+
+                # Define reference data: Ignore lines with invalid lat/lon info
+                # (here 0, 1, 2, 7, 8, 9)
+                new_start_line = max(3, start_line)
+                new_end_line = min(6, end_line)
+                lats_ref = lats[new_start_line:new_end_line + 1, :]
+                qualflags_ref = qualflags[new_start_line:new_end_line+1]
+                qualflags_pre = qualflags
+
+                # Midnight scanline has to be updated to new slice
+                midnight_scanline_ref = midnight_scanline - new_start_line
+
+                # Define Tester
+                def test(satellite_name, startdate, enddate, starttime, endtime,
+                         lats, lons, ref1, ref2, ref3, bt3, bt4, bt5,
+                         sun_zen, sat_zen, sun_azi, sat_azi, rel_azi,
+                         qual_flags, start_line, end_line,
+                         total_number_of_scan_lines, last_scan_line_number,
+                         corr, gac_file, midnight_scanline, miss_lines):
+                    """Check whether scanlines with invalid lat/lon info have
+                     been excluded correctly"""
+
+                    # Rescale lats
+                    lats[np.where(lats != fv)] /= 1000
+
+                    # Test whether the arrays have been sliced correctly
+                    self.assertTrue(
+                        np.all(lats == lats_ref),
+                        msg='Latitude has not been sliced correctly ' + where
+                    )
+                    self.assertTrue(
+                        np.all(qual_flags == qualflags_ref),
+                        msg='Qualflags have not been sliced correctly ' + where
+                    )
+
+                    # If missing lines are tracked correctly, the union of
+                    # pre-slicing scanline numbers and post-slicing missing
+                    # lines should include all scanlines
+                    self.assertEqual(
+                        set(qualflags_pre[:, 0]).union(set(miss_lines)),
+                        set(range(1, 14+1)),
+                        msg='Missing scanlines have not been tracked '
+                            'correctly ' + where
+                    )
+
+                    # Check whether midnigt scanline has been updated correctly
+                    self.assertEqual(
+                        midnight_scanline, midnight_scanline_ref,
+                        msg='Midnight scanline has not been updated '
+                            'correctly ' + where
+                    )
+
+                    # TODO: Check UTCs once they are available (feature-time).
+
+                # Patch gac_io.avhrrGAC_io using the above tester
+                pygac.gac_io.avhrrGAC_io = test
+
+                # Call save_gac which then calls the tester instead of
+                # gac_io.avhrrGAC_io
+                pygac.gac_io.save_gac(
+                    satellite_name='dummy',
+                    xutcs=xutcs,
+                    lats=lats,
+                    lons=lons,
+                    ref1=dummydata,
+                    ref2=dummydata,
+                    ref3=dummydata,
+                    bt3=dummydata,
+                    bt4=dummydata,
+                    bt5=dummydata,
+                    sun_zen=dummydata,
+                    sat_zen=dummydata,
+                    sun_azi=dummydata,
+                    sat_azi=dummydata,
+                    rel_azi=dummydata,
+                    mask=np.zeros(lats.shape, dtype='bool'),
+                    qual_flags=qualflags,
+                    start_line=start_line,
+                    end_line=end_line,
+                    tsmcorr=False,
+                    gac_file='dummy',
+                    midnight_scanline=midnight_scanline,
+                    miss_lines=miss_lines,
+                    switch=np.zeros(lats.shape, dtype='bool')
+                )
+
+        # Delete the module as we don't want the patched methods to affect
+        # other tests
+        del pygac.gac_io
+
+
+def suite():
+    """The suite for test_io"""
+    loader = unittest.TestLoader()
+    mysuite = unittest.TestSuite()
+    mysuite.addTest(loader.loadTestsFromTestCase(TestIO))
+    return mysuite
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/pygac/tests/test_io.py
+++ b/pygac/tests/test_io.py
@@ -100,13 +100,14 @@ class TestIO(unittest.TestCase):
                 lats_ref = lats[new_start_line:new_end_line + 1, :]
                 qualflags_ref = qualflags[new_start_line:new_end_line+1]
                 qualflags_pre = qualflags
+                xutcs_ref = xutcs[new_start_line:new_end_line + 1]
 
                 # Midnight scanline has to be updated to new slice
                 midnight_scanline_ref = midnight_scanline - new_start_line
 
                 # Define Tester
-                def test(satellite_name, startdate, enddate, starttime, endtime,
-                         lats, lons, ref1, ref2, ref3, bt3, bt4, bt5,
+                def test(satellite_name, xutcs, startdate, enddate, starttime,
+                         endtime, lats, lons, ref1, ref2, ref3, bt3, bt4, bt5,
                          sun_zen, sat_zen, sun_azi, sat_azi, rel_azi,
                          qual_flags, start_line, end_line,
                          total_number_of_scan_lines, last_scan_line_number,
@@ -126,6 +127,10 @@ class TestIO(unittest.TestCase):
                         np.all(qual_flags == qualflags_ref),
                         msg='Qualflags have not been sliced correctly ' + where
                     )
+                    self.assertTrue(
+                        np.all(xutcs == xutcs_ref),
+                        msg='UTC times have not been sliced correctly ' + where
+                    )
 
                     # If missing lines are tracked correctly, the union of
                     # pre-slicing scanline numbers and post-slicing missing
@@ -143,8 +148,6 @@ class TestIO(unittest.TestCase):
                         msg='Midnight scanline has not been updated '
                             'correctly ' + where
                     )
-
-                    # TODO: Check UTCs once they are available (feature-time).
 
                 # Patch gac_io.avhrrGAC_io using the above tester
                 pygac.gac_io.avhrrGAC_io = test

--- a/pygac/tests/test_reader.py
+++ b/pygac/tests/test_reader.py
@@ -58,8 +58,7 @@ class TestGacReader(unittest.TestCase):
 
         # Define test cases...
         # ... midnight scanline exists
-        utcs1 = (24 * 3600 * 1000 + np.array([-3, -2, -1, 0, 1, 2, 3])).astype(
-            'datetime64[ms]')
+        utcs1 = np.array([-3, -2, -1, 0, 1, 2, 3]).astype('datetime64[ms]')
         scanline1 = 2
 
         # ... midnight scanline does not exist


### PR DESCRIPTION
Remake of #12 

I believe there is a bug in ``pygac.gac_io.save_gac``. User defined scanlines are not selected correctly in the presence of scanlines with invalid lat/lon info:

1) Choose new temporary start/end lines due to invalid lat/lon info: ``data = data[temp_start_line:temp_end_line]``
2) Adjust user defined ``start_line/end_line`` to new slice
3) Select user defined scanlines ``data = data[start_line, end_line]``

I believe step 2 is not done correctly. Here is a sketch with the details: [pygac_2step_slice.pdf](https://github.com/pytroll/pygac/files/1044289/pygac_2step_slice.pdf)

The consequence for CLARA-A2 is, that we get scanlines beyond the requested range from pygac. As the range was chosen to avoid overlap between consecutive orbits, we re-introduce an overlap of ``temp_start_line`` scanlines. I did a quick CLARA-A2 logfile analysis:

| Year | Platform | # of files with temp_start_line > 0 | Average temp_start_line | Standard Deviation  |
| ---: |:--:| ----:| ----:| ----:|
| 2011 | NK | 5520 | 15   | 0.16 |
| 2011 | NL | 5493 | 15   | 0.12 |
| 2011 | NN | 5509 | 15   | 0.44 |
| 2011 | M2 | 7507 | 15   | 0.18 |
| 2011 | NP | 5505 | 15   | 1.89 |
| 1984 | NC |    3 | 1202 | 625  |

In 2011 almost every orbit from every platform is affected, but luckily the average temp_start_line is 15, which is not a serious problem. In 1984, the additional overlap is quite significant, but only very few orbits are affected.
Cloud_cci is not affected at all, because they always process all scanlines.