### PR TITLE
Fix TLE line identification

### DIFF
--- a/pygac/tests/test_reader.py
+++ b/pygac/tests/test_reader.py
@@ -25,21 +25,6 @@ import numpy as np
 from pygac.gac_reader import GACReader
 
 
-class GACReaderDummy(GACReader):
-    def _get_times(self):
-        pass
-
-    def get_header_timestamp(self):
-        pass
-
-    def read(self, filename):
-        pass
-
-    @property
-    def tsm_affected_intervals(self):
-        pass
-
-
 class TestGacReader(unittest.TestCase):
     """Test the common GAC Reader"""
 
@@ -53,9 +38,10 @@ class TestGacReader(unittest.TestCase):
                          msg='Conversion from (year, jday, msec) to datetime64 '
                              'is not correct')
 
-    def test_midnight_scanline(self):
+    @mock.patch.multiple('pygac.gac_reader.GACReader', __abstractmethods__=set())
+    def test_midnight_scanline(self, *mocks):
         """Test midnight scanline computation"""
-        reader = GACReaderDummy()
+        reader = GACReader()
 
         # Define test cases...
         # ... midnight scanline exists
@@ -73,9 +59,10 @@ class TestGacReader(unittest.TestCase):
             self.assertEqual(reader.get_midnight_scanline(), scanline,
                              msg='Incorrect midnight scanline')
 
-    def test_miss_lines(self):
+    @mock.patch.multiple('pygac.gac_reader.GACReader', __abstractmethods__=set())
+    def test_miss_lines(self, *mocks):
         """Test detection of missing scanlines"""
-        reader = GACReaderDummy()
+        reader = GACReader()
         lines = [2, 4, 5, 6, 10, 11, 12]
         miss_lines_ref = [1, 3, 7, 8, 9]
         reader.scans = np.zeros(len(lines), dtype=[('scan_line_number', 'i2')])

--- a/pygac/tests/test_reader.py
+++ b/pygac/tests/test_reader.py
@@ -20,6 +20,7 @@
 
 import datetime
 import unittest
+import mock
 import numpy as np
 from pygac.gac_reader import GACReader
 
@@ -73,6 +74,7 @@ class TestGacReader(unittest.TestCase):
                              msg='Incorrect midnight scanline')
 
     def test_miss_lines(self):
+        """Test detection of missing scanlines"""
         reader = GACReaderDummy()
         lines = [2, 4, 5, 6, 10, 11, 12]
         miss_lines_ref = [1, 3, 7, 8, 9]
@@ -80,6 +82,48 @@ class TestGacReader(unittest.TestCase):
         reader.scans['scan_line_number'] = lines
         self.assertTrue((reader.get_miss_lines() == miss_lines_ref).all(),
                         msg='Missing scanlines not detected correctly')
+
+    def test_tle2datetime64(self, *mocks):
+        """Test conversion from TLE timestamps to datetime64"""
+        dates = np.array([70365.1234, 18001.25])
+        dates64_exp = [np.datetime64(datetime.datetime(1970, 12, 31, 2, 57, 41, 760000), '[ms]'),
+                       np.datetime64(datetime.datetime(2018, 1, 1, 6, 0), '[ms]')]
+        dates64 = GACReader.tle2datetime64(dates)
+        self.assertTrue(np.all(dates64 == dates64_exp))
+
+    @mock.patch.multiple('pygac.gac_reader.GACReader', __abstractmethods__=set())
+    @mock.patch('pygac.gac_reader.GACReader.get_tle_file')
+    def test_get_tle_lines(self, get_tle_file, *mocks):
+        """Test identification of closest TLE lines"""
+        tle_data = ['1 38771U 12049A   18363.63219793 -.00000013  00000-0  14176-4 0  9991\r\n',
+                    '2 38771  98.7297  60.1350 0002062  95.9284  25.0713 14.21477560325906\r\n',
+                    '1 38771U 12049A   18364.62426010 -.00000015  00000-0  13136-4 0  9990\r\n',  # 2018-12-30 14:58
+                    '2 38771  98.7295  61.1159 0002062  94.5796  60.2561 14.21477636326047\r\n',
+                    '1 38771U 12049A   18364.94649306 -.00000018  00000-0  12040-4 0  9996\r\n',  # 2018-12-30 22:42
+                    '2 38771  98.7295  61.4345 0002060  94.1226 268.7521 14.21477633326092\r\n',
+                    '1 38771U 12049A   18365.81382142 -.00000015  00000-0  13273-4 0  9991\r\n',
+                    '2 38771  98.7294  62.2921 0002057  92.7653  26.0030 14.21477711326215\r\n']
+
+        expected = {
+            datetime.datetime(2018, 12, 20, 12, 0): None,
+            datetime.datetime(2018, 12, 28, 12, 0): 0,
+            datetime.datetime(2018, 12, 30, 16, 0): 2,
+            datetime.datetime(2018, 12, 30, 20, 0): 4,
+            datetime.datetime(2019, 1, 1, 12, 0): 6,
+            datetime.datetime(2019, 1, 8, 12, 0): None
+        }
+
+        get_tle_file.return_value = tle_data
+        reader = GACReader()
+        for time, tle_idx in expected.items():
+            reader.times = [time]
+            reader.tle_lines = None
+            if tle_idx is None:
+                self.assertRaises(IndexError, reader.get_tle_lines, threshold=7)
+            else:
+                tle1, tle2 = reader.get_tle_lines(threshold=7)
+                self.assertEqual(tle1, tle_data[tle_idx])
+                self.assertEqual(tle2, tle_data[tle_idx + 1])
 
 
 def suite():


### PR DESCRIPTION
Fixes #20

Problems:
- If ``sdate > dates[-1]`` then ``np.searchsorted(dates, sdate)`` returns ``len(dates)`` which is beyond the array bounds.
- The simple float representation of TLE timestamps has problems near the turn of the year. For example 2019001.1234 - 2018365.1234 = 636 days...