### PR TITLE
Add get_times to angles computation

### DIFF
--- a/pygac/gac_reader.py
+++ b/pygac/gac_reader.py
@@ -347,6 +347,7 @@ class GACReader(object):
         return tle1, tle2
 
     def get_angles(self):
+        self.get_times()
         tle1, tle2 = self.get_tle_lines(threshold=self.tle_thresh)
         orb = Orbital(self.spacecrafts_orbital[self.spacecraft_id],
                       line1=tle1, line2=tle2)


### PR DESCRIPTION
If angles are to be computed first, the times need to be available. This PR enables times computation for the angles
