### PR TITLE
Fix update of missing scanlines

### DIFF
--- a/pygac/gac_reader.py
+++ b/pygac/gac_reader.py
@@ -792,7 +792,7 @@ class GACReader(six.with_metaclass(ABCMeta)):
         # find the missing line numbers.
         ideal = set(range(1, self.scans['scan_line_number'][-1] + 1))
         missing = sorted(ideal.difference(set(self.scans['scan_line_number'])))
-        return np.array(missing)
+        return np.array(missing, dtype=int)
 
     def mask_tsm_pixels(self, channels):
         """Mask pixels affected by the scan motor issue."""

--- a/pygac/tests/test_io.py
+++ b/pygac/tests/test_io.py
@@ -62,6 +62,16 @@ class TestIO(unittest.TestCase):
                 miss_lines=miss_lines, qual_flags=qual_flags, **t)
             numpy.testing.assert_array_equal(miss_lines, miss_lines_exp)
 
+        # If intersection of miss_lines and qual_flags is not empty
+        # (here: extra "1" in miss_lines), make sure that items are
+        # not added twice.
+        miss_lines = utils._update_missing_scanlines(
+            miss_lines=np.array([1, 3, 7, 10]),
+            qual_flags=qual_flags,
+            start_line=3, end_line=6)
+        numpy.testing.assert_array_equal(miss_lines,
+                                         [1, 2, 3, 4, 7, 10, 11, 12])
+
     def test_slice(self):
         ch = np.array([[1, 2, 3, 4, 5]]).transpose()
         sliced_exp = np.array([[2, 3, 4]]).transpose()

--- a/pygac/tests/test_reader.py
+++ b/pygac/tests/test_reader.py
@@ -146,8 +146,10 @@ class TestGacReader(unittest.TestCase):
         self.reader.scans = np.zeros(
             len(lines), dtype=[('scan_line_number', 'i2')])
         self.reader.scans['scan_line_number'] = lines
-        self.assertTrue((self.reader.get_miss_lines() == miss_lines_ref).all(),
+        miss_lines = self.reader.get_miss_lines()
+        self.assertTrue((miss_lines == miss_lines_ref).all(),
                         msg='Missing scanlines not detected correctly')
+        self.assertEqual(miss_lines.dtype, int)
 
     def test_tle2datetime64(self, *mocks):
         """Test conversion from TLE timestamps to datetime64."""

--- a/pygac/utils.py
+++ b/pygac/utils.py
@@ -30,6 +30,14 @@ def check_user_scanlines(start_line, end_line, first_valid_lat=None,
     """Check user-defined scanlines.
 
     Can be used by both pygac and satpy.
+
+    Args:
+        start_line: User-defined start line (afer stripping, if enabled)
+        end_line: User-defined end line (afer stripping, if enabled)
+        first_valid_lat: First scanline with valid latitudes
+        last_valid_lat: Last scanline with valid latitudes
+        along_track: Number of scanlines (only needed if stripping
+            is disabled)
     """
     if first_valid_lat is not None and last_valid_lat is not None:
         num_valid_lines = last_valid_lat - first_valid_lat + 1
@@ -155,7 +163,7 @@ def _update_missing_scanlines(miss_lines, qual_flags, start_line, end_line):
         start_line: New start line of the slice
         end_line: New end line of the slice
     """
-    return np.sort(np.array(
+    return np.sort(np.unique(
         qual_flags[0:start_line, 0].tolist() +
         miss_lines.tolist() +
         qual_flags[end_line + 1:, 0].tolist()


### PR DESCRIPTION
If selecting user-defined scanlines or stripping scanlines with invalid coordinates, the list of missing scanlines is updated using `pygac.utils._update_missing_scanlines`. But under certain circumstances (e.g. calling that method twice), the updated list would contain duplicates. That is fixed by this PR.