### PR TITLE
Fixing geotiepoints attribute error for python2.7

### DIFF
--- a/pygac/gac_reader.py
+++ b/pygac/gac_reader.py
@@ -41,7 +41,7 @@ from pyorbital.orbital import Orbital
 from pyorbital import astronomy
 import datetime
 from pygac.calibration import calibrate_solar, calibrate_thermal
-import pygac.geotiepoints as gtp
+import pygac.pygac_geotiepoints as gtp
 
 LOG = logging.getLogger(__name__)
 

--- a/pygac/pygac_geotiepoints.py
+++ b/pygac/pygac_geotiepoints.py
@@ -32,10 +32,9 @@ import numpy as np
 def Gac_Lat_Lon_Interpolator(lons_subset, lats_subset):
     """Interpolate lat-lon values in the AVHRR GAC data.
 
-    Each GAC row has total 409 pixels.
-    But lat-lon values are provided for every eigth pixel.
-    They start at from pixel 5 and at pixel 405.
-    Interpolate to full resolution.
+    Each GAC row has 409 pixels.
+    But lat-lon values are provided for every eigth pixel,
+    ranging from 5 to 405. Interpolate to full resolution.
 
     """
     # cols_subset = np.arange(0, 404, 8)

--- a/pygac/pygac_geotiepoints.py
+++ b/pygac/pygac_geotiepoints.py
@@ -49,9 +49,9 @@ def Gac_Lat_Lon_Interpolator(lons_subset, lats_subset):
     cross_track_order = 3
 
     satint = gtp.SatelliteInterpolator((lons_subset, lats_subset),
-                                       (rows_subset, cols_subset),
-                                       (rows_full, cols_full),
-                                       along_track_order,
-                                       cross_track_order)
+                                   (rows_subset, cols_subset),
+                                   (rows_full, cols_full),
+                                   along_track_order,
+                                   cross_track_order)
 
     return satint.interpolate()

--- a/pygac/pygac_geotiepoints.py
+++ b/pygac/pygac_geotiepoints.py
@@ -21,8 +21,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-"""Interpolation of geographical tiepoints.
-"""
+"""Interpolation of geographical tiepoints."""
 
 
 import geotiepoints as gtp
@@ -30,12 +29,14 @@ import geotiepoints as gtp
 import numpy as np
 
 
-
 def Gac_Lat_Lon_Interpolator(lons_subset, lats_subset):
-    """Interpolate lat-lon values in the AVHRR GAC data from every eigth pixel to all pixels.
+    """Interpolate lat-lon values in the AVHRR GAC data.
 
-    Each GAC row has total 409 pixels. But lat-lon values are provided for every eigth pixel
-    starting from pixel 5 and ending at pixel 405.
+    Each GAC row has total 409 pixels.
+    But lat-lon values are provided for every eigth pixel.
+    They start at from pixel 5 and at pixel 405.
+    Interpolate to full resolution.
+
     """
     # cols_subset = np.arange(0, 404, 8)
     # cols_full = np.arange(405)
@@ -49,9 +50,9 @@ def Gac_Lat_Lon_Interpolator(lons_subset, lats_subset):
     cross_track_order = 3
 
     satint = gtp.SatelliteInterpolator((lons_subset, lats_subset),
-                                   (rows_subset, cols_subset),
-                                   (rows_full, cols_full),
-                                   along_track_order,
-                                   cross_track_order)
+                                       (rows_subset, cols_subset),
+                                       (rows_full, cols_full),
+                                       along_track_order,
+                                       cross_track_order)
 
     return satint.interpolate()

--- a/pygac/tests/test_reader.py
+++ b/pygac/tests/test_reader.py
@@ -112,6 +112,19 @@ class TestGacReader(unittest.TestCase):
             method.asser_not_called()
 
     @mock.patch('pygac.gac_reader.GACReader._get_corrupt_mask')
+    @mock.patch('pygac.gac_reader.GACReader._adjust_clock_drift')
+    @mock.patch('pygac.gac_reader.GACReader._get_lonlat')
+    def test_interpolate(self, _get_lonlat, _adjust_clock_drift, _get_corrupt_mask):
+        """Test interpolate method in get_lonlat."""
+        self.lons = None
+        self.lats = None
+        lons = 90 * np.random.rand(17, 51)
+        lats = 90 * np.random.rand(17, 51)
+        _get_lonlat.return_value = lons, lats
+        self.interpolate_coors = True
+        lons, lats = self.reader.get_lonlat()
+
+    @mock.patch('pygac.gac_reader.GACReader._get_corrupt_mask')
     def test_get_corrupt_mask(self, get_corrupt_mask):
         """Test common computation of corrupt scanline mask."""
         get_corrupt_mask.return_value = [1, 2, 3]

--- a/pygac/tests/test_reader.py
+++ b/pygac/tests/test_reader.py
@@ -114,7 +114,8 @@ class TestGacReader(unittest.TestCase):
     @mock.patch('pygac.gac_reader.GACReader._get_corrupt_mask')
     @mock.patch('pygac.gac_reader.GACReader._adjust_clock_drift')
     @mock.patch('pygac.gac_reader.GACReader._get_lonlat')
-    def test_interpolate(self, _get_lonlat, _adjust_clock_drift, _get_corrupt_mask):
+    def test_interpolate(self, _get_lonlat, _adjust_clock_drift,
+                         _get_corrupt_mask):
         """Test interpolate method in get_lonlat."""
         self.lons = None
         self.lats = None
@@ -123,6 +124,7 @@ class TestGacReader(unittest.TestCase):
         _get_lonlat.return_value = lons, lats
         self.interpolate_coors = True
         lons, lats = self.reader.get_lonlat()
+        self.assertEqual(lons.shape[1], 409)
 
     @mock.patch('pygac.gac_reader.GACReader._get_corrupt_mask')
     def test_get_corrupt_mask(self, get_corrupt_mask):


### PR DESCRIPTION
Fixing  an AttributeError for python 2.7

Importing module geotiepoints from file named geotiepoints caused 
an error for python 2.7. Likely the local file was imported instead of the module.
The error message was:
AttributeError: 'module' object has no attribute 'SatelliteInterpolator'
A test that would have found the error is added.