### PR TITLE
Add meta_data dictionary to reader class.

### DIFF
--- a/pygac/__init__.py
+++ b/pygac/__init__.py
@@ -22,6 +22,7 @@
 
 import logging
 import os
+import numpy as np
 
 from pygac.version import __version__  # noqa
 
@@ -52,3 +53,10 @@ def centered_modulus(array, divisor):
     arr = array % divisor
     arr[arr > divisor / 2] -= divisor
     return arr
+
+
+def calculate_sun_earth_distance_correction(jday):
+    """Calculate the sun earth distance correction."""
+    # Earth-Sun distance correction factor
+    corr = 1.0 - 0.0334 * np.cos(2.0 * np.pi * (jday - 2) / 365.25)
+    return corr

--- a/pygac/__init__.py
+++ b/pygac/__init__.py
@@ -56,7 +56,15 @@ def centered_modulus(array, divisor):
 
 
 def calculate_sun_earth_distance_correction(jday):
-    """Calculate the sun earth distance correction."""
+    """Calculate the sun earth distance correction.
+
+    In 2008 3-4 different equations of ESD were considered.
+    This one was chosen as it at the time gave reflectances most closely
+    matching the PATMOS-x data provided then by Andy Heidinger.
+
+    Formula might need to be reconsidered if jday is updated to a float.
+
+    """
     # Earth-Sun distance correction factor
     corr = 1.0 - 0.0334 * np.cos(2.0 * np.pi * (jday - 2) / 365.25)
     return corr

--- a/pygac/gac_io.py
+++ b/pygac/gac_io.py
@@ -83,7 +83,7 @@ def save_gac(satellite_name,
              bt3, bt4, bt5,
              sun_zen, sat_zen, sun_azi, sat_azi, rel_azi,
              qual_flags, start_line, end_line,
-             gac_file, midnight_scanline, miss_lines):
+             gac_file, midnight_scanline, miss_lines, meta_data):
 
     last_scan_line_number = qual_flags[-1, 0]
 
@@ -199,10 +199,9 @@ def save_gac(satellite_name,
     starttime = start.strftime("%H%M%S%f")[:-5]
     enddate = end.strftime("%Y%m%d")
     endtime = end.strftime("%H%M%S%f")[:-5]
-    jday = int(start.strftime("%j"))
 
     # Earth-Sun distance correction factor
-    corr = 1.0 - 0.0334 * np.cos(2.0 * np.pi * (jday - 2) / 365.25)
+    corr = meta_data['sun_earth_distance_correction_factor']
 
     # Apply scaling & offset
     bt3 -= 273.15

--- a/pygac/gac_io.py
+++ b/pygac/gac_io.py
@@ -83,7 +83,11 @@ def save_gac(satellite_name,
              bt3, bt4, bt5,
              sun_zen, sat_zen, sun_azi, sat_azi, rel_azi,
              qual_flags, start_line, end_line,
-             gac_file, midnight_scanline, miss_lines, meta_data):
+             gac_file, meta_data):
+
+    midnight_scanline = meta_data['midnight_scanline']
+    miss_lines = meta_data['miss_lines']
+    corr = meta_data['sun_earth_distance_correction_factor']
 
     last_scan_line_number = qual_flags[-1, 0]
 
@@ -199,9 +203,6 @@ def save_gac(satellite_name,
     starttime = start.strftime("%H%M%S%f")[:-5]
     enddate = end.strftime("%Y%m%d")
     endtime = end.strftime("%H%M%S%f")[:-5]
-
-    # Earth-Sun distance correction factor
-    corr = meta_data['sun_earth_distance_correction_factor']
 
     # Apply scaling & offset
     bt3 -= 273.15

--- a/pygac/gac_io.py
+++ b/pygac/gac_io.py
@@ -86,7 +86,7 @@ def save_gac(satellite_name,
              gac_file, meta_data):
 
     midnight_scanline = meta_data['midnight_scanline']
-    miss_lines = meta_data['miss_lines']
+    miss_lines = meta_data['missing_scanlines']
     corr = meta_data['sun_earth_distance_correction_factor']
 
     last_scan_line_number = qual_flags[-1, 0]

--- a/pygac/gac_klm.py
+++ b/pygac/gac_klm.py
@@ -625,7 +625,8 @@ def main(filename, start_line, end_line):
                     qual_flags, start_line, end_line,
                     reader.filename,
                     reader.get_midnight_scanline(),
-                    reader.get_miss_lines())
+                    reader.get_miss_lines(),
+                    reader.meta_data)
     LOG.info("pygac took: %s", str(datetime.datetime.now() - tic))
 
 

--- a/pygac/gac_klm.py
+++ b/pygac/gac_klm.py
@@ -624,8 +624,6 @@ def main(filename, start_line, end_line):
                     sun_zen, sat_zen, sun_azi, sat_azi, rel_azi,
                     qual_flags, start_line, end_line,
                     reader.filename,
-                    reader.get_midnight_scanline(),
-                    reader.get_miss_lines(),
                     reader.meta_data)
     LOG.info("pygac took: %s", str(datetime.datetime.now() - tic))
 

--- a/pygac/gac_pod.py
+++ b/pygac/gac_pod.py
@@ -431,7 +431,8 @@ def main(filename, start_line, end_line):
                     qual_flags, start_line, end_line,
                     reader.filename,
                     reader.get_midnight_scanline(),
-                    reader.get_miss_lines())
+                    reader.get_miss_lines(),
+                    reader.meta_data)
     LOG.info("pygac took: %s", str(datetime.datetime.now() - tic))
 
 

--- a/pygac/gac_pod.py
+++ b/pygac/gac_pod.py
@@ -430,8 +430,6 @@ def main(filename, start_line, end_line):
                     sun_zen, sat_zen, sun_azi, sat_azi, rel_azi,
                     qual_flags, start_line, end_line,
                     reader.filename,
-                    reader.get_midnight_scanline(),
-                    reader.get_miss_lines(),
                     reader.meta_data)
     LOG.info("pygac took: %s", str(datetime.datetime.now() - tic))
 

--- a/pygac/gac_reader.py
+++ b/pygac/gac_reader.py
@@ -64,6 +64,7 @@ class GACReader(six.with_metaclass(ABCMeta)):
             tle_thresh: Maximum number of days between observation and nearest
                 TLE
         """
+        self.meta_data = {}
         self.interpolate_coords = interpolate_coords
         self.adjust_clock_drift = adjust_clock_drift
         self.tle_dir = tle_dir
@@ -264,6 +265,9 @@ class GACReader(six.with_metaclass(ABCMeta)):
 
         # Earth-Sun distance correction factor
         corr = 1.0 - 0.0334 * np.cos(2.0 * np.pi * (jday - 2) / 365.25)
+
+        # Save the factor
+        self.meta_data['sun_earth_distance_correction_factor'] = corr
 
         # how many reflective channels are there ?
         tot_ref = channels.shape[2] - 3

--- a/pygac/gac_reader.py
+++ b/pygac/gac_reader.py
@@ -272,8 +272,9 @@ class GACReader(six.with_metaclass(ABCMeta)):
                 self.get_sun_earth_distance_correction())
         if 'midnight_scanline' not in self.meta_data.keys():
             self.meta_data['midnight_scanline'] = self.get_midnight_scanline()
-        if 'miss_lines' not in self.meta_data.keys():
-            self.meta_data['miss_lines'] = self.get_miss_lines()
+        if 'missing_scanlines' not in self.meta_data.keys():
+            self.meta_data['missing_scanlines'] = (
+                self.get_miss_lines()).astype(int)
 
     def get_calibrated_channels(self):
         """Calibrate the solar channels."""

--- a/pygac/gac_reader.py
+++ b/pygac/gac_reader.py
@@ -260,21 +260,18 @@ class GACReader(six.with_metaclass(ABCMeta)):
     def get_sun_earth_distance_correction(self):
         """Get the julian day and the sun-earth distance correction."""
         self.get_times()
-        year = self.times[0].year
-        delta = self.times[0].date() - datetime.date(year, 1, 1)
-        jday = delta.days + 1
+        jday = self.times[0].timetuple().tm_yday
         return calculate_sun_earth_distance_correction(jday)
 
     def update_meta_data(self):
         """Add some metd data to the meta_data dicitonary."""
-        if 'sun_earth_distance_correction_factor' not in self.meta_data.keys():
+        if 'sun_earth_distance_correction_factor' not in self.meta_data:
             self.meta_data['sun_earth_distance_correction_factor'] = (
                 self.get_sun_earth_distance_correction())
-        if 'midnight_scanline' not in self.meta_data.keys():
+        if 'midnight_scanline' not in self.meta_data:
             self.meta_data['midnight_scanline'] = self.get_midnight_scanline()
-        if 'missing_scanlines' not in self.meta_data.keys():
-            self.meta_data['missing_scanlines'] = (
-                self.get_miss_lines()).astype(int)
+        if 'missing_scanlines' not in self.meta_data:
+            self.meta_data['missing_scanlines'] = self.get_miss_lines()
 
     def get_calibrated_channels(self):
         """Calibrate the solar channels."""
@@ -282,8 +279,7 @@ class GACReader(six.with_metaclass(ABCMeta)):
         self.get_times()
         self.update_meta_data()
         year = self.times[0].year
-        delta = self.times[0].date() - datetime.date(year, 1, 1)
-        jday = delta.days + 1
+        jday = self.times[0].timetuple().tm_yday
 
         corr = self.meta_data['sun_earth_distance_correction_factor']
 

--- a/pygac/gac_reader.py
+++ b/pygac/gac_reader.py
@@ -31,6 +31,7 @@ import six
 import types
 
 from pygac import (CONFIG_FILE, centered_modulus,
+                   calculate_sun_earth_distance_correction,
                    get_absolute_azimuth_angle_diff)
 try:
     import ConfigParser
@@ -257,6 +258,7 @@ class GACReader(six.with_metaclass(ABCMeta)):
         return lons.reshape(-1, width), lats.reshape(-1, width)
 
     def get_calibrated_channels(self):
+        """Calibrate the solar channels."""
         channels = self.get_counts()
         self.get_times()
         year = self.times[0].year
@@ -264,7 +266,7 @@ class GACReader(six.with_metaclass(ABCMeta)):
         jday = delta.days + 1
 
         # Earth-Sun distance correction factor
-        corr = 1.0 - 0.0334 * np.cos(2.0 * np.pi * (jday - 2) / 365.25)
+        corr = calculate_sun_earth_distance_correction(jday)
 
         # Save the factor
         self.meta_data['sun_earth_distance_correction_factor'] = corr

--- a/pygac/tests/test_init.py
+++ b/pygac/tests/test_init.py
@@ -1,11 +1,11 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-# Copyright (c) 2013, 2014 Martin Raspaud
+# Copyright (c) 2014-2019 Pytroll Developers
 
 # Author(s):
 
-#   Martin Raspaud <martin.raspaud@smhi.se>
+#   Nina Hakansson <nina.hakansson@smhi.se>
 
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -20,23 +20,31 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-"""The tests package.
-"""
+"""Test function for the angle calculation."""
 
-from pygac.tests import (test_calibrate_pod, test_slerp, test_calibrate_klm,
-                         test_pod, test_tsm, test_reader, test_io,
-                         test_angles, test_init)
 import unittest
 
+import numpy as np
+
+from pygac import calculate_sun_earth_distance_correction
+
+
+class TestInit(unittest.TestCase):
+    """Test function for the angle calculation."""
+
+    def test_calculate_sun_earth_distance_correction(self):
+        """Test function for the sun distance corretction."""
+        corr = calculate_sun_earth_distance_correction(3)
+        np.testing.assert_almost_equal(corr, 0.96660494, decimal=7)
 
 def suite():
-    """The global test suite.
-    """
+    """Testing functions from pygac init files."""
+    loader = unittest.TestLoader()
     mysuite = unittest.TestSuite()
-    tests = (test_slerp, test_calibrate_klm, test_calibrate_pod,
-             test_pod, test_tsm, test_reader, test_io, test_angles,
-             test_init)
-    for test in tests:
-        mysuite.addTests(test.suite())
+    mysuite.addTest(loader.loadTestsFromTestCase(TestInit))
 
     return mysuite
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/pygac/tests/test_init.py
+++ b/pygac/tests/test_init.py
@@ -37,8 +37,9 @@ class TestInit(unittest.TestCase):
         corr = calculate_sun_earth_distance_correction(3)
         np.testing.assert_almost_equal(corr, 0.96660494, decimal=7)
 
+
 def suite():
-    """Testing functions from pygac init files."""
+    """Test non angle functions in pygac init file."""
     loader = unittest.TestLoader()
     mysuite = unittest.TestSuite()
     mysuite.addTest(loader.loadTestsFromTestCase(TestInit))

--- a/pygac/tests/test_io.py
+++ b/pygac/tests/test_io.py
@@ -213,7 +213,8 @@ class TestIO(unittest.TestCase):
             qual_flags=mm,
             gac_file=mm,
             midnight_scanline=mm,
-            miss_lines=mm
+            miss_lines=mm,
+            meta_data=mm
         )
         slice_channel.return_value = mm, 'miss', 'midnight'
         strip_invalid_lat.return_value = 0, 0

--- a/pygac/tests/test_io.py
+++ b/pygac/tests/test_io.py
@@ -212,8 +212,6 @@ class TestIO(unittest.TestCase):
             rel_azi=mm,
             qual_flags=mm,
             gac_file=mm,
-            midnight_scanline=mm,
-            miss_lines=mm,
             meta_data=mm
         )
         slice_channel.return_value = mm, 'miss', 'midnight'

--- a/pygac/tests/test_reader.py
+++ b/pygac/tests/test_reader.py
@@ -343,8 +343,11 @@ class TestGacReader(unittest.TestCase):
 
     def test_calculate_sun_earth_distance_correction(self):
         """Test the calculate sun earth distance correction method."""
-        from pygac import calculate_sun_earth_distance_correction
-        corr = calculate_sun_earth_distance_correction(3)
+        self.reader.utcs = np.array([315748035469, 315748359969,
+                                     315751135469, 315754371969,
+                                     315754371969]).astype('datetime64[ms]')
+        self.reader.times = self.reader.to_datetime(self.reader.utcs)
+        corr = self.reader.get_sun_earth_distance_correction()
         numpy.testing.assert_almost_equal(corr, 0.96660494, decimal=7)
 
 

--- a/pygac/tests/test_reader.py
+++ b/pygac/tests/test_reader.py
@@ -341,6 +341,12 @@ class TestGacReader(unittest.TestCase):
         self.reader.correct_times_thresh()
         numpy.testing.assert_array_equal(self.reader.utcs, utcs_expected)
 
+    def test_calculate_sun_earth_distance_correction(self):
+        """Test the calculate sun earth distance correction method."""
+        from pygac import calculate_sun_earth_distance_correction
+        corr = calculate_sun_earth_distance_correction(3)
+        numpy.testing.assert_almost_equal(corr, 0.96660494, decimal=7)
+
 
 def suite():
     """Test suite for test_reader."""


### PR DESCRIPTION
Calculate the sun_earth_distance_correction_factor only once. 
Add it to meta_data dictionary in reader class.

For now meta_data contain only sun_earth_distance_correction_factor. 
But the idea (Martin's) is that updating some attributes in pygac in 
the future should not always require a PR to satpy. 

PR will solve issue #40. 