### PR TITLE
Update metadata when reading lonlat also

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,8 @@
+exclude: '^$'
+fail_fast: false
+repos:
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v2.2.3
+    hooks:
+    - id: flake8
+      additional_dependencies: [flake8-docstrings, flake8-debugger, flake8-bugbear]

--- a/pygac/reader.py
+++ b/pygac/reader.py
@@ -385,6 +385,7 @@ class Reader(six.with_metaclass(ABCMeta)):
         """
         if self.lons is None and self.lats is None:
             self.lons, self.lats = self._get_lonlat()
+            self.update_meta_data()
 
             # Interpolate from every eighth pixel to all pixels.
             if self.interpolate_coords:

--- a/pygac/tests/test_reader.py
+++ b/pygac/tests/test_reader.py
@@ -61,11 +61,13 @@ class TestGacReader(unittest.TestCase):
         """Test scanline timestamp estimation."""
         self.assertEqual(self.reader.lineno2msec(12345), 6172000)
 
+    @mock.patch('pygac.reader.Reader.update_meta_data')
     @mock.patch('pygac.gac_reader.GACReader._get_lonlat')
     @mock.patch('pygac.gac_reader.GACReader._get_corrupt_mask')
     @mock.patch('pygac.gac_reader.GACReader._adjust_clock_drift')
     def test_get_lonlat(self, adjust_clockdrift,
-                        get_corrupt_mask, get_lonlat):
+                        get_corrupt_mask, get_lonlat,
+                        update_meta_data):
         """Test common lon/lat computation."""
         lon_i = np.array([np.nan, 1, 2, 3, -180.1, 180.1])
         lat_i = np.array([1, 2, 3, np.nan, -90.1, 90.1])
@@ -80,6 +82,7 @@ class TestGacReader(unittest.TestCase):
         # Default
         lons, lats = self.reader.get_lonlat()
         get_lonlat.assert_called()
+        update_meta_data.assert_called()
         adjust_clockdrift.assert_called()
         numpy.testing.assert_array_equal(lons, lons_exp)
         numpy.testing.assert_array_equal(lats, lats_exp)
@@ -117,11 +120,12 @@ class TestGacReader(unittest.TestCase):
         for method in methods:
             method.asser_not_called()
 
+    @mock.patch('pygac.reader.Reader.update_meta_data')
     @mock.patch('pygac.gac_reader.GACReader._get_corrupt_mask')
     @mock.patch('pygac.gac_reader.GACReader._adjust_clock_drift')
     @mock.patch('pygac.gac_reader.GACReader._get_lonlat')
     def test_interpolate(self, _get_lonlat, _adjust_clock_drift,
-                         _get_corrupt_mask):
+                         _get_corrupt_mask, update_meta_data):
         """Test interpolate method in get_lonlat."""
         self.lons = None
         self.lats = None

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[flake8]
+max-line-length = 120


### PR DESCRIPTION
The `get_lonlat` function wasn't updating the metadata, which caused trouble when reading lons and lats before calibrated channels.