### PR TITLE
allow gzip compressed files as input for klm and pod readers read method

### DIFF
--- a/pygac/klm_reader.py
+++ b/pygac/klm_reader.py
@@ -588,8 +588,8 @@ class KLMReader(Reader):
 
         """
         with self._open(filename) as fd_:
-            # Note that np.fromfile does not work with gzip.GzipFile 
-            # objects (numpy version 1.16.4), because it restricts the 
+            # Note that np.fromfile does not work with gzip.GzipFile
+            # objects (numpy version 1.16.4), because it restricts the
             # file objects to (io.FileIO, io.BufferedReader, io.BufferedWriter)
             # see: numpy.compat.py3k.isfileobj
             self.ars_head, = np.frombuffer(
@@ -608,17 +608,17 @@ class KLMReader(Reader):
                 "noaa_level_1b_format_version_number"]
             if self.header_version >= 5:
                 self.analog_telemetry, = np.frombuffer(
-                    fd_.read(analog_telemetry_v5.itemsize), 
+                    fd_.read(analog_telemetry_v5.itemsize),
                     dtype=analog_telemetry_v5, count=1)
             else:
                 self.analog_telemetry, = np.frombuffer(
-                    fd_.read(analog_telemetry_v2.itemsize), 
+                    fd_.read(analog_telemetry_v2.itemsize),
                     dtype=analog_telemetry_v2, count=1)
             # LAC: 1, GAC: 2, ...
             self.data_type = self.head['data_type_code']
             fd_.seek(self.offset + ars_offset, 0)
             self.scans = np.frombuffer(
-                fd_.read(), 
+                fd_.read(),
                 dtype=self.scanline_type,
                 count=self.head["count_of_data_records"])
 

--- a/pygac/klm_reader.py
+++ b/pygac/klm_reader.py
@@ -9,6 +9,7 @@
 #   Sajid Pareeth <sajid.pareeth@fmach.it>
 #   Martin Raspaud <martin.raspaud@smhi.se>
 #   Adam Dybbroe <adam.dybbroe@smhi.se>
+#   Carlos Horn <carlos.horn@external.eumetsat.int>
 
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/pygac/pod_reader.py
+++ b/pygac/pod_reader.py
@@ -220,7 +220,7 @@ class PODReader(Reader):
         with self._open(filename) as fd_:
             # read archive header
             self.tbm_head, = np.frombuffer(
-                fd_.read(tbm_header.itemsize), 
+                fd_.read(tbm_header.itemsize),
                 dtype=tbm_header, count=1)
             if ((not self.tbm_head['data_set_name'].startswith(self.creation_site + b'.')) and
                     (self.tbm_head['data_set_name'] != b'\x00' * 42 + b'  ')):
@@ -247,7 +247,7 @@ class PODReader(Reader):
 
             fd_.seek(tbm_offset, 0)
             self.head, = np.frombuffer(
-                fd_.read(header.itemsize), 
+                fd_.read(header.itemsize),
                 dtype=header, count=1)
             fd_.seek(self.offset + tbm_offset, 0)
             self.scans = np.frombuffer(

--- a/pygac/pod_reader.py
+++ b/pygac/pod_reader.py
@@ -8,6 +8,7 @@
 #   Adam Dybbroe <adam.dybbroe@smhi.se>
 #   Sajid Pareeth <sajid.pareeth@fmach.it>
 #   Martin Raspaud <martin.raspaud@smhi.se>
+#   Carlos Horn <carlos.horn@external.eumetsat.int>
 
 # This work was done in the framework of ESA-CCI-Clouds phase I
 

--- a/pygac/reader.py
+++ b/pygac/reader.py
@@ -123,14 +123,14 @@ class Reader(six.with_metaclass(ABCMeta)):
             filename (str): Specifies the GAC/LAC file to be read.
         """
         raise NotImplementedError
-        
+
     @contextmanager
     def _open(self, filename):
         """Open the GAC/LAC data file and yield the filehandle.
-        
+
         Args:
             filename (str): Path to GAC/LAC file to open
-            
+
         Note:
             This method should be called inside the Reader.read implementation
         """

--- a/pygac/reader.py
+++ b/pygac/reader.py
@@ -30,6 +30,8 @@ import numpy as np
 import os
 import six
 import types
+import gzip
+from contextlib import contextmanager
 
 from pygac import (CONFIG_FILE, centered_modulus,
                    calculate_sun_earth_distance_correction,
@@ -120,8 +122,31 @@ class Reader(six.with_metaclass(ABCMeta)):
         Args:
             filename (str): Specifies the GAC/LAC file to be read.
         """
-        self.filename = os.path.basename(filename)
+        raise NotImplementedError
+        
+    @contextmanager
+    def _open(self, filename):
+        """Open the GAC/LAC data file and yield the filehandle.
+        
+        Args:
+            filename (str): Path to GAC/LAC file to open
+            
+        Note:
+            This method should be called inside the Reader.read implementation
+        """
+        basename = os.path.basename(filename)
+        root, ext = os.path.splitext(basename)
+        if ext == ".gz":
+            self.filename = root
+            file_object = gzip.open(filename, mode='rb')
+        else:
+            self.filename = basename
+            file_object = open(filename, mode='rb')
         LOG.info('Reading %s', self.filename)
+        try:
+            yield file_object
+        finally:
+            file_object.close()
 
     @abstractmethod
     def get_header_timestamp(self):

--- a/pygac/reader.py
+++ b/pygac/reader.py
@@ -6,6 +6,7 @@
 # Author(s):
 
 #   Martin Raspaud <martin.raspaud@smhi.se>
+#   Carlos Horn <carlos.horn@external.eumetsat.int>
 
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/pygac/tests/test_reader.py
+++ b/pygac/tests/test_reader.py
@@ -4,6 +4,7 @@
 # Author(s):
 
 #   Stephan Finkensieper <stephan.finkensieper@dwd.de>
+#   Carlos Horn <carlos.horn@external.eumetsat.int>
 
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -42,6 +43,17 @@ class TestGacReader(unittest.TestCase):
         """Set up the tests."""
         self.interpolator = interpolator
         self.reader = GACReader()
+
+    @mock.patch('pygac.reader.open', mock.mock_open(read_data='normal'))
+    @mock.patch('pygac.reader.gzip.open', mock.mock_open(read_data='gzip'))
+    def test__open(self):
+        """Test if proper opener is used."""
+        with self.reader._open("test_file") as f:
+            content_normal = f.read()
+        self.assertEqual(content_normal, 'normal')
+        with self.reader._open("test_file.gz") as f:
+            content_gzip = f.read()
+        self.assertEqual(content_gzip, 'gzip')
 
     def test_to_datetime64(self):
         """Test conversion from (year, jday, msec) to datetime64."""


### PR DESCRIPTION
This implementation should close #52.

I have tested it with python 3.7, but everything I used is part of the standard python library and should therefore be compatible with any python version >= 2.7.