### PR TITLE
Fix metadata update

### DIFF
--- a/pygac/reader.py
+++ b/pygac/reader.py
@@ -411,7 +411,6 @@ class Reader(six.with_metaclass(ABCMeta)):
         """
         if self.lons is None and self.lats is None:
             self.lons, self.lats = self._get_lonlat()
-            self.update_meta_data()
 
             # Interpolate from every eighth pixel to all pixels.
             if self.interpolate_coords:
@@ -421,6 +420,7 @@ class Reader(six.with_metaclass(ABCMeta)):
             # Adjust clock drift
             if self.adjust_clock_drift:
                 self._adjust_clock_drift()
+            self.update_meta_data()
 
             # Mask out corrupt scanlines
             self.lons[self.mask] = np.nan

--- a/pygac/tests/test_reader.py
+++ b/pygac/tests/test_reader.py
@@ -92,10 +92,17 @@ class TestGacReader(unittest.TestCase):
         lats_exp = np.array([1, 2, np.nan, np.nan, np.nan, np.nan])
 
         # Default
+        call_order = mock.Mock()
+        call_order.attach_mock(adjust_clockdrift, 'adjust_clockdrift')
+        call_order.attach_mock(update_meta_data, 'update_meta_data')
+
         lons, lats = self.reader.get_lonlat()
+
+        call_order.assert_has_calls(
+            [mock.call.adjust_clockdrift(),
+             mock.call.update_meta_data()]
+        )  # clock adjusted *before* metadata update?
         get_lonlat.assert_called()
-        update_meta_data.assert_called()
-        adjust_clockdrift.assert_called()
         numpy.testing.assert_array_equal(lons, lons_exp)
         numpy.testing.assert_array_equal(lats, lats_exp)
 


### PR DESCRIPTION
Make sure clockdrift is adjusted *before* the metadata update. Otherwise the midnight scanline will not be updated.