### PR TITLE
Make Calibrator work without config file

### DIFF
--- a/pygac/calibration.py
+++ b/pygac/calibration.py
@@ -148,8 +148,11 @@ class Calibrator(object):
             coeffs_file = /path/to/user/default/coeffs.json
         """
         # check if the user has set a coefficient file
-        config = pygac.configuration.get_config()
-        coeffs_file = config.get("calibration", "coeffs_file", fallback='')
+        try:
+            config = pygac.configuration.get_config()
+            coeffs_file = config.get("calibration", "coeffs_file", fallback='')
+        except KeyError:
+            coeffs_file = ''
         # if no coeffs file has been specified, use the pygac defaults
         if not coeffs_file:
             coeffs_file = resource_filename('pygac', 'data/calibration.json')

--- a/pygac/reader.py
+++ b/pygac/reader.py
@@ -102,7 +102,8 @@ class Reader(six.with_metaclass(ABCMeta)):
             tle_thresh: Maximum number of days between observation and nearest
                 TLE
             creation_site: The three-letter identifier of the creation site (eg 'NSS')
-            calibration: dictionary with satellite specific calibration coefficients
+            calibration: Custom calibration coefficients. Either dictionary with satellite
+                specific calibration coefficients, or path to coefficient file.
             filename: GAC/LAC filename
 
         """

--- a/pygac/tests/test_calibration_coefficients.py
+++ b/pygac/tests/test_calibration_coefficients.py
@@ -123,14 +123,14 @@ class TestCalibrationCoefficientsHandling(unittest.TestCase):
     @mock.patch('pygac.calibration.open', mock.mock_open(read_data=user_json_file))
     def test_user_coefficients_file(self):
         # reset coefficients
-        Calibrator.default_coeffs = None
+        Calibrator.coeffs = None
         Calibrator._version = None
 
         if sys.version_info.major < 3:
             cal = Calibrator('noaa19')
         else:
             with self.assertWarnsRegex(RuntimeWarning,
-                                       "Unknown default calibration coefficients version!"):
+                                       "Unknown calibration coefficients version!"):
                 cal = Calibrator('noaa19')
 
         self.assertEqual(cal.dark_count[0], 0)
@@ -148,7 +148,7 @@ class TestCalibrationCoefficientsHandling(unittest.TestCase):
         np.testing.assert_allclose(scaled_radiance, counts)
 
         # re-reset coefficients
-        Calibrator.default_coeffs = None
+        Calibrator.coeffs = None
         Calibrator._version = None
 
     def test_custom_coefficients(self):


### PR DESCRIPTION
At the moment `Calibrator.load_defaults` expects a config file to be present. In the satpy use case we usually don't have that. This PR makes the calibrator work without a config file. 

@carloshorn @mraspaud I wonder if it would make sense to allow the `calibration` reader keyword argument to be a path to the json file? Then we could use it like that:

```python
scn = satpy.Scene(filenames=..., reader_kwargs={'calibration': 'my_config.json'})
```

At the moment I would have to read the json file myself and pass the dictionary.