### PR TITLE
Add raw GAC header to metadata

### DIFF
--- a/pygac/gac_io.py
+++ b/pygac/gac_io.py
@@ -39,7 +39,6 @@ from pygac.utils import slice_channel, strip_invalid_lat, check_user_scanlines
 
 LOG = logging.getLogger(__name__)
 
-
 MISSING_DATA = -32001
 MISSING_DATA_LATLON = -999999
 
@@ -65,9 +64,6 @@ def save_gac(satellite_name,
              sun_zen, sat_zen, sun_azi, sat_azi, rel_azi,
              qual_flags, start_line, end_line,
              gac_file, meta_data):
-
-    midnight_scanline = meta_data['midnight_scanline']
-    miss_lines = meta_data['missing_scanlines']
     corr = meta_data['sun_earth_distance_correction_factor']
 
     last_scan_line_number = qual_flags[-1, 0]
@@ -89,91 +85,81 @@ def save_gac(satellite_name,
         last_valid_lat=last_valid_lat)
 
     # Slice data using new start/end lines
-    _, miss_lines, midnight_scanline = slice_channel(
-        np.zeros(lats.shape),
-        start_line=start_line,
-        end_line=end_line,
-        first_valid_lat=first_valid_lat,
-        last_valid_lat=last_valid_lat,
-        qual_flags=qual_flags,
-        miss_lines=miss_lines,
-        midnight_scanline=midnight_scanline)
-
-    ref1, _, _ = slice_channel(ref1,
+    ref1 = slice_channel(ref1,
+                         start_line=start_line,
+                         end_line=end_line,
+                         first_valid_lat=first_valid_lat,
+                         last_valid_lat=last_valid_lat)
+    ref2 = slice_channel(ref2,
+                         start_line=start_line,
+                         end_line=end_line,
+                         first_valid_lat=first_valid_lat,
+                         last_valid_lat=last_valid_lat)
+    ref3 = slice_channel(ref3,
+                         start_line=start_line,
+                         end_line=end_line,
+                         first_valid_lat=first_valid_lat,
+                         last_valid_lat=last_valid_lat)
+    bt3 = slice_channel(bt3,
+                        start_line=start_line,
+                        end_line=end_line,
+                        first_valid_lat=first_valid_lat,
+                        last_valid_lat=last_valid_lat)
+    bt4 = slice_channel(bt4,
+                        start_line=start_line,
+                        end_line=end_line,
+                        first_valid_lat=first_valid_lat,
+                        last_valid_lat=last_valid_lat)
+    bt5 = slice_channel(bt5,
+                        start_line=start_line,
+                        end_line=end_line,
+                        first_valid_lat=first_valid_lat,
+                        last_valid_lat=last_valid_lat)
+    sun_zen = slice_channel(sun_zen,
+                            start_line=start_line,
+                            end_line=end_line,
+                            first_valid_lat=first_valid_lat,
+                            last_valid_lat=last_valid_lat)
+    sun_azi = slice_channel(sun_azi,
+                            start_line=start_line,
+                            end_line=end_line,
+                            first_valid_lat=first_valid_lat,
+                            last_valid_lat=last_valid_lat)
+    sat_zen = slice_channel(sat_zen,
+                            start_line=start_line,
+                            end_line=end_line,
+                            first_valid_lat=first_valid_lat,
+                            last_valid_lat=last_valid_lat)
+    sat_azi = slice_channel(sat_azi,
+                            start_line=start_line,
+                            end_line=end_line,
+                            first_valid_lat=first_valid_lat,
+                            last_valid_lat=last_valid_lat)
+    rel_azi = slice_channel(rel_azi,
+                            start_line=start_line,
+                            end_line=end_line,
+                            first_valid_lat=first_valid_lat,
+                            last_valid_lat=last_valid_lat)
+    lons = slice_channel(lons,
+                         start_line=start_line,
+                         end_line=end_line,
+                         first_valid_lat=first_valid_lat,
+                         last_valid_lat=last_valid_lat)
+    lats = slice_channel(lats,
+                         start_line=start_line,
+                         end_line=end_line,
+                         first_valid_lat=first_valid_lat,
+                         last_valid_lat=last_valid_lat)
+    qual_flags = slice_channel(qual_flags,
                                start_line=start_line,
                                end_line=end_line,
                                first_valid_lat=first_valid_lat,
                                last_valid_lat=last_valid_lat)
-    ref2, _, _ = slice_channel(ref2,
-                               start_line=start_line,
-                               end_line=end_line,
-                               first_valid_lat=first_valid_lat,
-                               last_valid_lat=last_valid_lat)
-    ref3, _, _ = slice_channel(ref3,
-                               start_line=start_line,
-                               end_line=end_line,
-                               first_valid_lat=first_valid_lat,
-                               last_valid_lat=last_valid_lat)
-    bt3, _, _ = slice_channel(bt3,
-                              start_line=start_line,
-                              end_line=end_line,
-                              first_valid_lat=first_valid_lat,
-                              last_valid_lat=last_valid_lat)
-    bt4, _, _ = slice_channel(bt4,
-                              start_line=start_line,
-                              end_line=end_line,
-                              first_valid_lat=first_valid_lat,
-                              last_valid_lat=last_valid_lat)
-    bt5, _, _ = slice_channel(bt5,
-                              start_line=start_line,
-                              end_line=end_line,
-                              first_valid_lat=first_valid_lat,
-                              last_valid_lat=last_valid_lat)
-    sun_zen, _, _ = slice_channel(sun_zen,
-                                  start_line=start_line,
-                                  end_line=end_line,
-                                  first_valid_lat=first_valid_lat,
-                                  last_valid_lat=last_valid_lat)
-    sun_azi, _, _ = slice_channel(sun_azi,
-                                  start_line=start_line,
-                                  end_line=end_line,
-                                  first_valid_lat=first_valid_lat,
-                                  last_valid_lat=last_valid_lat)
-    sat_zen, _, _ = slice_channel(sat_zen,
-                                  start_line=start_line,
-                                  end_line=end_line,
-                                  first_valid_lat=first_valid_lat,
-                                  last_valid_lat=last_valid_lat)
-    sat_azi, _, _ = slice_channel(sat_azi,
-                                  start_line=start_line,
-                                  end_line=end_line,
-                                  first_valid_lat=first_valid_lat,
-                                  last_valid_lat=last_valid_lat)
-    rel_azi, _, _ = slice_channel(rel_azi,
-                                  start_line=start_line,
-                                  end_line=end_line,
-                                  first_valid_lat=first_valid_lat,
-                                  last_valid_lat=last_valid_lat)
-    lons, _, _ = slice_channel(lons,
-                               start_line=start_line,
-                               end_line=end_line,
-                               first_valid_lat=first_valid_lat,
-                               last_valid_lat=last_valid_lat)
-    lats, _, _ = slice_channel(lats,
-                               start_line=start_line,
-                               end_line=end_line,
-                               first_valid_lat=first_valid_lat,
-                               last_valid_lat=last_valid_lat)
-    qual_flags, _, _ = slice_channel(qual_flags,
-                                     start_line=start_line,
-                                     end_line=end_line,
-                                     first_valid_lat=first_valid_lat,
-                                     last_valid_lat=last_valid_lat)
-    xutcs, _, _ = slice_channel(xutcs,
-                                start_line=start_line,
-                                end_line=end_line,
-                                first_valid_lat=first_valid_lat,
-                                last_valid_lat=last_valid_lat)
+    xutcs = slice_channel(xutcs,
+                          start_line=start_line,
+                          end_line=end_line,
+                          first_valid_lat=first_valid_lat,
+                          last_valid_lat=last_valid_lat)
 
     total_number_of_scan_lines = lats.shape[0]
 
@@ -206,16 +192,14 @@ def save_gac(satellite_name,
                 lats, lons, ref1, ref2, ref3, bt3, bt4, bt5,
                 sun_zen, sat_zen, sun_azi, sat_azi, rel_azi, qual_flags,
                 start_line, end_line, total_number_of_scan_lines,
-                last_scan_line_number, corr, gac_file, midnight_scanline,
-                miss_lines)
+                last_scan_line_number, corr, gac_file)
 
 
 def avhrrGAC_io(satellite_name, xutcs, startdate, enddate, starttime, endtime,
                 arrLat_full, arrLon_full, ref1, ref2, ref3, bt3, bt4, bt5,
                 arrSZA, arrSTZ, arrSAA, arrSTA, arrRAA, qual_flags,
                 start_line, end_line, total_number_of_scan_lines,
-                last_scan_line_number, corr, gac_file, midnight_scanline,
-                miss_lines):
+                last_scan_line_number, corr, gac_file):
     import os
 
     # Read output dir etc from config file
@@ -633,13 +617,9 @@ def avhrrGAC_io(satellite_name, xutcs, startdate, enddate, starttime, endtime,
     g1.attrs["last_scan_line_number"] = last_scan_line_number
 
     g2 = fout.require_group("/ancillary")
-    dset2 = g2.create_dataset("missing_scanlines", dtype='int16',
-                              data=miss_lines)
-    del dset2
     dset3 = g2.create_dataset("scanline_timestamps", dtype='int64',
                               data=xutcs.astype('int64'))
     dset3.attrs['units'] = 'Milliseconds since 1970-01-01 00:00:00 UTC'
     dset3.attrs['calendar'] = 'standard'
-    g2.attrs["midnight_scanline"] = np.string_(midnight_scanline)
 
     fout.close()

--- a/pygac/reader.py
+++ b/pygac/reader.py
@@ -532,10 +532,8 @@ class Reader(six.with_metaclass(ABCMeta)):
         if 'sun_earth_distance_correction_factor' not in self.meta_data:
             self.meta_data['sun_earth_distance_correction_factor'] = (
                 self.get_sun_earth_distance_correction())
-        if 'midnight_scanline' not in self.meta_data:
-            self.meta_data['midnight_scanline'] = self.get_midnight_scanline()
-        if 'missing_scanlines' not in self.meta_data:
-            self.meta_data['missing_scanlines'] = self.get_miss_lines()
+        if 'gac_header' not in self.meta_data:
+            self.meta_data['gac_header'] = self.head
 
     def get_calibrated_channels(self):
         """Calibrate and return the channels."""

--- a/pygac/reader.py
+++ b/pygac/reader.py
@@ -590,7 +590,6 @@ class Reader(six.with_metaclass(ABCMeta)):
         """
         if self.lons is None and self.lats is None:
             self.lons, self.lats = self._get_lonlat()
-            self.update_meta_data()
 
             # Interpolate from every eighth pixel to all pixels.
             if self.interpolate_coords:
@@ -1044,41 +1043,6 @@ class Reader(six.with_metaclass(ABCMeta)):
         except KeyError:
             # Platform is not affected at all
             return False
-
-    def get_midnight_scanline(self):
-        """Find the scanline where the UTC date increases by one day.
-
-        Returns:
-            int: The midnight scanline if it exists and is unique.
-                 None, else.
-
-        """
-        self.get_times()
-        d0 = np.datetime64(datetime.date(1970, 1, 1), 'D')
-        days = (self.utcs.astype('datetime64[D]') - d0).astype(int)
-        incr = np.where(np.diff(days) == 1)[0]
-        if len(incr) != 1:
-            if len(incr) > 1:
-                LOG.warning('Unable to determine midnight scanline: '
-                            'UTC date increases more than once. ')
-            return None
-        else:
-            return incr[0]
-
-    def get_miss_lines(self):
-        """Find missing scanlines.
-
-        I.e. scanlines which were dropped for some reason or were never recorded.
-
-        Returns:
-            Indices of missing scanlines
-
-        """
-        # Compare scanline number against the ideal case (1, 2, 3, ...) and
-        # find the missing line numbers.
-        ideal = set(range(1, self.scans['scan_line_number'][-1] + 1))
-        missing = sorted(ideal.difference(set(self.scans['scan_line_number'])))
-        return np.array(missing, dtype=int)
 
     def mask_tsm_pixels(self, channels):
         """Mask pixels affected by the scan motor issue."""

--- a/pygac/tests/test_io.py
+++ b/pygac/tests/test_io.py
@@ -150,11 +150,12 @@ class TestIO(unittest.TestCase):
         self.assertRaises(ValueError, gac_io.check_user_scanlines,
                           110, 120, None, None, 100)
 
+    @mock.patch('pygac.gac_io.avhrrGAC_io')
     @mock.patch('pygac.gac_io.strip_invalid_lat')
     @mock.patch('pygac.gac_io.slice_channel')
     @mock.patch('pygac.gac_io.check_user_scanlines')
     def test_save_gac(self, check_user_scanlines, slice_channel,
-                      strip_invalid_lat):
+                      strip_invalid_lat, avhrr_gac_io):
         """Test saving."""
         # Test scanline selection
         mm = mock.MagicMock()
@@ -187,6 +188,35 @@ class TestIO(unittest.TestCase):
                                          start_line='start', end_line='end',
                                          first_valid_lat=mock.ANY,
                                          last_valid_lat=mock.ANY)
+        expected_args = [
+            mock.ANY,
+            mock.ANY,
+            mock.ANY,
+            mock.ANY,
+            mock.ANY,
+            mock.ANY,
+            mock.ANY,
+            mock.ANY,
+            mock.ANY,
+            mock.ANY,
+            mock.ANY,
+            mock.ANY,
+            mock.ANY,
+            mock.ANY,
+            mock.ANY,
+            mock.ANY,
+            mock.ANY,
+            mock.ANY,
+            mock.ANY,
+            mock.ANY,
+            'start',
+            'end',
+            mock.ANY,
+            mock.ANY,
+            mock.ANY,
+            mock.ANY
+        ]
+        avhrr_gac_io.assert_called_with(*expected_args)
 
 
 def suite():


### PR DESCRIPTION
Add the raw GAC header to the metadata dictionary. Furthermore, remove derived metadata (i.e. midnight scanline and missing scanlines) as these can easily be computed by the user (via timestamps and qual flags).