### PR TITLE
Remove config dependency from reader class

### DIFF
--- a/pygac/calibration.py
+++ b/pygac/calibration.py
@@ -146,11 +146,11 @@ class Calibrator(object):
             coeffs (dict): dictionary containing coefficients for all satellites
             version (str): version of the coefficients (None if unknown)
         """
-        if coeffs_file is None:
+        if coeffs_file:
+            LOG.info('Read calibration coefficients from "%s"', coeffs_file)
+        else:
             LOG.debug("Read PyGAC internal calibration coefficients.")
             coeffs_file = resource_filename('pygac', 'data/calibration.json')
-        else:
-            LOG.info('Read calibration coefficients from "%s"', coeffs_file)
         with open(coeffs_file, mode='rb') as json_file:
             content = json_file.read()
             md5_hash = hashlib.md5(content)

--- a/pygac/calibration.py
+++ b/pygac/calibration.py
@@ -47,7 +47,7 @@ class Calibrator(object):
         default_coeffs: dictonary containing default values for all spacecrafts
     """
     version_hashs = {
-        'ee643f5737a5a1c91ef97833b7ec868c': 'PATMOS-x, v2017r1'  # version information
+        '963af9b66268475ed500ad7b37da33c5': 'PATMOS-x, v2017r1'  # version information
     }
     fields = [
         "dark_count", "gain_switch", "s0", "s1", "s2", "b",  # "b0", "b1", "b2",
@@ -60,20 +60,24 @@ class Calibrator(object):
     default_file = None
     default_version = None
 
-    def __new__(cls, spacecraft, custom_coeffs=None, default_file=None):
+    def __new__(cls, spacecraft, custom_coeffs=None, coeffs_file=None):
         """Creates a namedtuple for calibration coefficients of a given spacecraft
 
         Args:
             spacecraft (str): spacecraft name in pygac convention
             custom_coeffs (dict): custom coefficients (optional)
-            default_file (str): path to a default coefficents file (optional)
+            coeffs_file (str): path to coefficents file (optional)
 
         Returns:
             calibrator (namedtuple): calibration coefficients
+
+        Note:
+            The coefficients in coeffs_file serve as default values if no custom_coeffs
+            are given. If omitted, Calibrator uses the PyGAC internal defaults.
         """
-        if cls.default_coeffs is None or cls.default_file != default_file:
-            self.default_file = default_file
-            cls.default_coeffs, cls.default_version = cls.read_coeffs(default_file)
+        if cls.default_coeffs is None or cls.default_file != coeffs_file:
+            cls.default_file = coeffs_file
+            cls.default_coeffs, cls.default_version = cls.read_coeffs(coeffs_file)
         if custom_coeffs:
             LOG.info('Using following custom coefficients "%s".', custom_coeffs)
         customs = custom_coeffs or {}
@@ -126,7 +130,7 @@ class Calibrator(object):
         # remove time zone information (easier to handle in calculations)
         arraycoeffs["date_of_launch"] = date_of_launch.replace(tzinfo=None)
         arraycoeffs["spacecraft"] = spacecraft
-        arraycoeffs["version"] = self.defaut_version
+        arraycoeffs["version"] = cls.default_version
         if custom_coeffs:
             arraycoeffs["version"] = None
         # create namedtuple
@@ -153,7 +157,7 @@ class Calibrator(object):
             digest = md5_hash.hexdigest()
             version = cls.version_hashs.get(digest)
             if version is None:
-                warning = "Unknown default calibration coefficients version!"
+                warning = "Unknown calibration coefficients version!"
                 warnings.warn(warning, RuntimeWarning)
                 LOG.warning(warning)
             else:

--- a/pygac/gac_io.py
+++ b/pygac/gac_io.py
@@ -193,7 +193,7 @@ def save_gac(satellite_name,
                 sun_zen, sat_zen, sun_azi, sat_azi, rel_azi, qual_flags,
                 start_line, end_line, total_number_of_scan_lines,
                 last_scan_line_number, corr, gac_file, midnight_scanline,
-                miss_lines)
+                miss_lines, output_file_prefix, avhrr_dir, qual_dir, sunsatangles_dir)
 
 
 def avhrrGAC_io(satellite_name, xutcs, startdate, enddate, starttime, endtime,

--- a/pygac/reader.py
+++ b/pygac/reader.py
@@ -146,14 +146,11 @@ class Reader(six.with_metaclass(ABCMeta)):
     @property
     def calibration(self):
         """Get the property 'calibration'."""
-        if self.spacecraft_name is None:
-            calibration = None
-        else:
-            calibration = Calibrator(
-                self.spacecraft_name,
-                custom_coeffs=self.custom_calibration,
-                coeffs_file=self.calibration_file
-            )
+        calibration = Calibrator(
+            self.spacecraft_name,
+            custom_coeffs=self.custom_calibration,
+            coeffs_file=self.calibration_file
+        )
         return calibration
 
     @abstractmethod

--- a/pygac/reader.py
+++ b/pygac/reader.py
@@ -151,8 +151,8 @@ class Reader(six.with_metaclass(ABCMeta)):
         else:
             calibration = Calibrator(
                 self.spacecraft_name,
-                custom_coeffs=self.custom_calibration
-                defaults_file=self.calibration_file
+                custom_coeffs=self.custom_calibration,
+                coeffs_file=self.calibration_file
             )
         return calibration
 

--- a/pygac/reader.py
+++ b/pygac/reader.py
@@ -100,7 +100,7 @@ class Reader(six.with_metaclass(ABCMeta)):
             tle_thresh: Maximum number of days between observation and nearest
                 TLE
             creation_site: The three-letter identifier of the creation site (eg 'NSS')
-            custom_calibration: dictionary with a subset of user defined satellite specific 
+            custom_calibration: dictionary with a subset of user defined satellite specific
                                 calibration coefficients
             calibration_file: path to json file containing default calibrations
 
@@ -239,7 +239,7 @@ class Reader(six.with_metaclass(ABCMeta)):
         # each child class which implements this method, should call the
         # super method to enter into the method resolution order.
         # See https://docs.python.org/3/library/functions.html#super
-        # second use case “diamond diagrams”.
+        # second use case "diamond diagrams".
         # Check if the data set name matches the pattern
         LOG.debug("validate header")
         data_set_name = header['data_set_name'].decode(errors='ignore')

--- a/pygac/runner.py
+++ b/pygac/runner.py
@@ -86,12 +86,12 @@ def process_file(filename, start_line, end_line, fileobj=None):
 
     # reader specific values
     config = get_config()
-    tle_dir = conf.get('tle', 'tledir', raw=True)
-    tle_name = conf.get('tle', 'tlename', raw=True)
+    tle_dir = config.get('tle', 'tledir', raw=True)
+    tle_name = config.get('tle', 'tlename', raw=True)
     coeffs_file = config.get("calibration", "coeffs_file", fallback='')
     # output specific values
-    output_dir = conf.get('output', 'output_dir', raw=True)
-    output_file_prefix = conf.get('output', 'output_file_prefix', raw=True)
+    output_dir = config.get('output', 'output_dir', raw=True)
+    output_file_prefix = config.get('output', 'output_file_prefix', raw=True)
     avhrr_dir = os.environ.get('SM_AVHRR_DIR')
     qual_dir = os.environ.get('SM_AVHRR_DIR')
     sunsatangles_dir = os.environ.get('SM_SUNSATANGLES_DIR')

--- a/pygac/runner.py
+++ b/pygac/runner.py
@@ -92,9 +92,9 @@ def process_file(filename, start_line, end_line, fileobj=None):
     # output specific values
     output_dir = conf.get('output', 'output_dir', raw=True)
     output_file_prefix = conf.get('output', 'output_file_prefix', raw=True)
-    avhrr_dir =  = os.environ.get('SM_AVHRR_DIR')
+    avhrr_dir = os.environ.get('SM_AVHRR_DIR')
     qual_dir = os.environ.get('SM_AVHRR_DIR')
-    sunsatangles_dir =os.environ.get('SM_SUNSATANGLES_DIR')
+    sunsatangles_dir = os.environ.get('SM_SUNSATANGLES_DIR')
 
     # Keep the file open while searching for the reader class and later
     # creation of the instance.

--- a/pygac/tests/test_calibrate_klm.py
+++ b/pygac/tests/test_calibrate_klm.py
@@ -31,11 +31,9 @@ except ImportError:
     from unittest import mock
 import numpy as np
 
-from pygac.calibration import calibrate_solar, calibrate_thermal
-from pygac.configuration import _config
+from pygac.calibration import Calibrator, calibrate_solar, calibrate_thermal
 
 
-@mock.patch('pygac.configuration.get_config', mock.Mock(return_value=_config))
 class TestGenericCalibration(unittest.TestCase):
 
     def test_calibration_vis(self):
@@ -49,23 +47,21 @@ class TestGenericCalibration(unittest.TestCase):
         year = 2010
         jday = 1
         spacecraft_id = "noaa19"
+        cal = Calibrator(spacecraft_id)
         corr = 1
         channel = 0
 
-        ref1 = calibrate_solar(counts[:, channel::5], channel, year, jday,
-                               spacecraft_id, corr)
+        ref1 = calibrate_solar(counts[:, channel::5], channel, year, jday, cal, corr)
 
         channel = 1
 
-        ref2 = calibrate_solar(counts[:, channel::5], channel, year, jday,
-                               spacecraft_id, corr)
+        ref2 = calibrate_solar(counts[:, channel::5], channel, year, jday, cal, corr)
 
         channel = 2
 
         data = np.ma.array(counts[:, channel::5], mask=True)
 
-        ref3 = calibrate_solar(data, channel, year, jday,
-                               spacecraft_id, corr)
+        ref3 = calibrate_solar(data, channel, year, jday, cal, corr)
 
         expected = (np.array([[np.nan, 27.37909518, 110.60103456],
                               [0.11943135, 6.03671211, 57.99695154]]),
@@ -96,13 +92,14 @@ class TestGenericCalibration(unittest.TestCase):
                                  [986.3,  992.3,  988.9]])
 
         spacecraft_id = "noaa19"
+        cal = Calibrator(spacecraft_id)
         ch3 = calibrate_thermal(counts[:, 2::5],
                                 prt_counts,
                                 ict_counts[:, 0],
                                 space_counts[:, 0],
                                 line_numbers=np.array([1, 2, 3]),
                                 channel=3,
-                                spacecraft=spacecraft_id)
+                                cal=cal)
 
         expected_ch3 = np.array([[298.36742, 305.248478, 293.238328],
                                  [296.960275, 306.493766, 294.488956],
@@ -116,7 +113,7 @@ class TestGenericCalibration(unittest.TestCase):
                                 space_counts[:, 1],
                                 line_numbers=np.array([1, 2, 3]),
                                 channel=4,
-                                spacecraft=spacecraft_id)
+                                cal=cal)
 
         expected_ch4 = np.array([[326.576534, 275.348988, 197.688755],
                                  [323.013104, 313.207077, 249.36352],
@@ -130,7 +127,7 @@ class TestGenericCalibration(unittest.TestCase):
                                 space_counts[:, 2],
                                 line_numbers=np.array([1, 2, 3]),
                                 channel=5,
-                                spacecraft=spacecraft_id)
+                                cal=cal)
 
         expected_ch5 = np.array([[326.96161, 272.090164, 188.267991],
                                  [323.156317, 312.673269, 244.184452],

--- a/pygac/tests/test_calibrate_pod.py
+++ b/pygac/tests/test_calibrate_pod.py
@@ -31,11 +31,9 @@ except ImportError:
     from unittest import mock
 import numpy as np
 
-from pygac.calibration import calibrate_solar, calibrate_thermal
-from pygac.configuration import _config
+from pygac.calibration import Calibrator, calibrate_solar, calibrate_thermal
 
 
-@mock.patch('pygac.configuration.get_config', mock.Mock(return_value=_config))
 class TestGenericCalibration(unittest.TestCase):
 
     def test_calibration_vis(self):
@@ -49,24 +47,22 @@ class TestGenericCalibration(unittest.TestCase):
         year = 1997
         jday = 196
         spacecraft_id = "noaa14"
+        cal = Calibrator(spacecraft_id)
         corr = 1
 
         channel = 0
 
-        ref1 = calibrate_solar(counts[:, channel::5], channel, year, jday,
-                               spacecraft_id, corr)
+        ref1 = calibrate_solar(counts[:, channel::5], channel, year, jday, cal, corr)
 
         channel = 1
 
-        ref2 = calibrate_solar(counts[:, channel::5], channel, year, jday,
-                               spacecraft_id, corr)
+        ref2 = calibrate_solar(counts[:, channel::5], channel, year, jday, cal, corr)
 
         channel = 2
 
         data = np.ma.array(counts[:, channel::5], mask=True)
 
-        ref3 = calibrate_solar(data, channel, year, jday,
-                               spacecraft_id, corr)
+        ref3 = calibrate_solar(data, channel, year, jday, cal, corr)
 
         expected = (np.array([[np.nan, 60.891074, 126.953364],
                               [0., 14.091565, 85.195791]]),
@@ -98,13 +94,14 @@ class TestGenericCalibration(unittest.TestCase):
                                  [986.3,  992.3,  988.9]])
 
         spacecraft_id = "noaa14"
+        cal = Calibrator(spacecraft_id)
         ch3 = calibrate_thermal(counts[:, 2::5],
                                 prt_counts,
                                 ict_counts[:, 0],
                                 space_counts[:, 0],
                                 line_numbers=np.array([1, 2, 3]),
                                 channel=3,
-                                spacecraft=spacecraft_id)
+                                cal=cal)
 
         expected_ch3 = np.array([[298.28466, 305.167571, 293.16182],
                                  [296.878502, 306.414234, 294.410224],
@@ -118,7 +115,7 @@ class TestGenericCalibration(unittest.TestCase):
                                 space_counts[:, 1],
                                 line_numbers=np.array([1, 2, 3]),
                                 channel=4,
-                                spacecraft=spacecraft_id)
+                                cal=cal)
 
         expected_ch4 = np.array([[325.828062, 275.414804, 196.214709],
                                  [322.359517, 312.785057, 249.380649],
@@ -132,7 +129,7 @@ class TestGenericCalibration(unittest.TestCase):
                                 space_counts[:, 2],
                                 line_numbers=np.array([1, 2, 3]),
                                 channel=5,
-                                spacecraft=spacecraft_id)
+                                cal=cal)
 
         expected_ch5 = np.array([[326.460316, 272.146547, 187.434456],
                                  [322.717606, 312.388155, 244.241633],

--- a/pygac/tests/test_io.py
+++ b/pygac/tests/test_io.py
@@ -212,7 +212,11 @@ class TestIO(unittest.TestCase):
             rel_azi=mm,
             qual_flags=mm,
             gac_file=mm,
-            meta_data=mm
+            meta_data=mm,
+            output_file_prefix=mm,
+            avhrr_dir=mm,
+            qual_dir=mm,
+            sunsatangles_dir=mm
         )
         slice_channel.return_value = mm, 'miss', 'midnight'
         strip_invalid_lat.return_value = 0, 0
@@ -222,7 +226,8 @@ class TestIO(unittest.TestCase):
         slice_channel.assert_called_with(mock.ANY,
                                          start_line='start', end_line='end',
                                          first_valid_lat=mock.ANY,
-                                         last_valid_lat=mock.ANY)
+                                         last_valid_lat=mock.ANY
+                                        )
         expected_args = [
             mock.ANY,
             mock.ANY,
@@ -251,7 +256,11 @@ class TestIO(unittest.TestCase):
             mock.ANY,
             mock.ANY,
             'midnight',
-            'miss'
+            'miss',
+            mock.ANY,
+            mock.ANY,
+            mock.ANY,
+            mock.ANY
         ]
         avhrr_gac_io.assert_called_with(*expected_args)
 

--- a/pygac/tests/test_io.py
+++ b/pygac/tests/test_io.py
@@ -227,7 +227,7 @@ class TestIO(unittest.TestCase):
                                          start_line='start', end_line='end',
                                          first_valid_lat=mock.ANY,
                                          last_valid_lat=mock.ANY
-                                        )
+                                         )
         expected_args = [
             mock.ANY,
             mock.ANY,

--- a/pygac/tests/test_reader.py
+++ b/pygac/tests/test_reader.py
@@ -338,21 +338,8 @@ class TestGacReader(unittest.TestCase):
         np.testing.assert_allclose(sun_zenith, expected_sun_zenith, atol=0.01)
         np.testing.assert_allclose(rel_azi, expected_rel_azi, atol=0.01)
 
-    @mock.patch('pygac.reader.get_config')
-    def test_get_tle_file(self, get_config):
+    def test_get_tle_file(self):
         """Test get_tle_file."""
-        # Use TLE name/dir from config file
-        class MockConfigParser(object):
-            def get(self, section, option, **kwargs):
-                if option == 'tledir':
-                    return 'path/to/TLEs'
-                elif option == 'tlename':
-                    return 'tle_file.txt'
-        get_config.return_value = MockConfigParser()
-        tle_file = self.reader.get_tle_file()
-        self.assertEqual(tle_file, 'path/to/TLEs/tle_file.txt')
-
-        # Use TLE name/dir from reader instanciation
         self.reader.tle_dir = '/tle/dir'
         self.reader.tle_name = 'tle_%(satname)s.txt'
         self.reader.spacecraft_name = 'ISS'


### PR DESCRIPTION
This PR should remove all module config dependency from the `Reader` class to make the usage consistent with external libraries.
This PR includes and extends the idea of #68.