### PR TITLE
Quality indicators

### DIFF
--- a/pygac/klm_reader.py
+++ b/pygac/klm_reader.py
@@ -33,6 +33,11 @@ http://www.ncdc.noaa.gov/oa/pod-guide/ncdc/docs/klm/html/c8/sec83142-1.htm
 
 import datetime
 import logging
+try:
+    from enum import IntFlag
+except ImportError:
+    # python version < 3.6
+    from enum import Enum as IntFlag
 
 import numpy as np
 
@@ -41,6 +46,50 @@ from pygac.reader import Reader, ReaderError
 from pygac.utils import file_opener
 
 LOG = logging.getLogger(__name__)
+
+
+class KLM_QualityIndicator(IntFlag):
+    """Quality Indicators
+
+    Source:
+        KLM guide
+        Table 8.3.1.3.3.1-1. Format of packed LAC/HRPT Data Sets (Version 2, pre-April 28, 2005).
+        Table 8.3.1.3.3.2-1. Format of LAC/HRPT Data Record for NOAA-N (Version 5, post-November 14,
+                             2006, all spacecraft).
+        Table 8.3.1.4.3.1-1. Format of packed GAC Data Record for NOAA KLM (Version 2, pre-April 28, 2005).
+        Table 8.3.1.4.3.2-1. Format of GAC Data Record for NOAA-N (Version 4, post-January 25, 2006,
+                             all spacecraft).
+
+    Note:
+        Table 8.3.1.3.3.1-1. and Table 8.3.1.4.3.1-1. define bit: 21 as
+        "frame sync word not valid"
+        Table 8.3.1.3.3.2-1. and Table 8.3.1.4.3.2-1. define bit: 21 as
+        "flywheeling detected during this frame"
+    """
+    FATAL_FLAG = 2**0  # Data should not be used for product generation
+    TIME_ERROR = 2**1  # Time sequence error detected within this scan
+    DATA_GAP = 2**2  # Data gap precedes this scan
+    CALIBRATION = 2**3  # Insufficient data for calibration
+    NO_EARTH_LOCATION = 2**4  # Earth location data not available
+    CLOCK_UPDATE = 2**5  # First good time following a clock update (nominally 0)
+    INSTRUMENT_CHANGE = 2**6  # Instrument status changed with this scan
+    BIT_SYNC_STATUS = 2**7  # Sync lock dropped during this frame
+    SYNC_ERROR = 2**8  # Frame sync word error greater than zero
+    FRAME_SYNC_LOCK = 2**9  # Frame sync previously dropped lock
+    SYNC_INVALID = 2**10  # Frame sync word not valid
+    FLYWHEELING = 2**10  # Flywheeling detected during this frame
+    BIT_SLIPPAGE = 2**11  # Bit slippage detected during this frame
+    TIP_PARITY = 2**23  # TIP parity error detected
+    # Reflected Sunlight (RS) detected
+    CH_3B_RS = 2**24
+    CH_3B_RS_ANOMALY = 2**25
+    CH_4_RS = 2**26
+    CH_4_RS_ANOMALY = 2**27
+    CH_5_RS = 2**28
+    CH_5_RS_ANOMALY = 2**29
+    DATA_JITTER = 2**30  # Resync occurred on this frame
+    PSEUDO_NOISE = 2**31  # Pseudo noise occurred on this frame
+
 
 # GAC header object
 
@@ -574,6 +623,8 @@ class KLMReader(Reader):
                            }
 
     tsm_affected_intervals = TSM_AFFECTED_INTERVALS_KLM
+    
+    QFlag = KLM_QualityIndicator
 
     def read(self, filename, fileobj=None):
         """Read the data.

--- a/pygac/klm_reader.py
+++ b/pygac/klm_reader.py
@@ -627,7 +627,7 @@ class KLMReader(Reader):
                            }
 
     tsm_affected_intervals = TSM_AFFECTED_INTERVALS_KLM
-    
+
     QFlag = KLM_QualityIndicator
 
     def read(self, filename, fileobj=None):

--- a/pygac/klm_reader.py
+++ b/pygac/klm_reader.py
@@ -629,6 +629,7 @@ class KLMReader(Reader):
     tsm_affected_intervals = TSM_AFFECTED_INTERVALS_KLM
 
     QFlag = KLM_QualityIndicator
+    _quality_indicators_key = "quality_indicator_bit_field"
 
     def read(self, filename, fileobj=None):
         """Read the data.

--- a/pygac/klm_reader.py
+++ b/pygac/klm_reader.py
@@ -49,7 +49,7 @@ LOG = logging.getLogger(__name__)
 
 
 class KLM_QualityIndicator(IntFlag):
-    """Quality Indicators
+    """Quality Indicators.
 
     Source:
         KLM guide
@@ -79,18 +79,18 @@ class KLM_QualityIndicator(IntFlag):
     SYNC_INVALID = 2**10  # Frame sync word not valid
     FLYWHEELING = 2**10  # Flywheeling detected during this frame
     BIT_SLIPPAGE = 2**11  # Bit slippage detected during this frame
+    # Note: 2**12 to 2**22 are not defined for KLMs
     TIP_PARITY = 2**23  # TIP parity error detected
-    # Reflected Sunlight (RS) detected
+    # Reflected Sunlight (RS) detected (solar blackbody contamination)
     CH_3B_RS = 2**24
+    CH_3_CONTAMINATION = 2**24  # POD compatible alias
     CH_3B_RS_ANOMALY = 2**25
     CH_4_RS = 2**26
+    CH_4_CONTAMINATION = 2**26  # POD compatible alias
     CH_4_RS_ANOMALY = 2**27
     CH_5_RS = 2**28
+    CH_5_CONTAMINATION = 2**28  # POD compatible alias
     CH_5_RS_ANOMALY = 2**29
-    # using same name as for POD
-    CH_3_CONTAMINATION = 2**24  # Channel 3 solar blackbody contamination
-    CH_4_CONTAMINATION = 2**26  # Channel 4 solar blackbody contamination
-    CH_5_CONTAMINATION = 2**28  # Channel 5 solar blackbody contamination
     DATA_JITTER = 2**30  # Resync occurred on this frame
     PSEUDO_NOISE = 2**31  # Pseudo noise occurred on this frame
 

--- a/pygac/pod_reader.py
+++ b/pygac/pod_reader.py
@@ -231,6 +231,7 @@ class PODReader(Reader):
     tsm_affected_intervals = TSM_AFFECTED_INTERVALS_POD
 
     QFlag = POD_QualityIndicator
+    _quality_indicators_key = "quality_indicators"
 
     def correct_scan_line_numbers(self):
         """Correct the scan line numbers."""

--- a/pygac/pod_reader.py
+++ b/pygac/pod_reader.py
@@ -60,15 +60,15 @@ class POD_QualityIndicator(IntFlag):
     # POD guide Table 3.1.2.1-2. Format of quality indicators.
     FATAL_FLAG = 2**0  # Data should not be used for product generation
     TIME_ERROR = 2**1  # A time sequence error was detected while Processing
-                 # this frame
+           # this frame
     DATA_GAP = 2**2  # A gap precedes this frame
     DATA_JITTER = 2**3  # Resync occurred on this frame
     CALIBRATION = 2**4  # Insufficient data for calibration
     NO_EARTH_LOCATION = 2**5  # Earth location data not available
     ASCEND_DESCEND = 2**6  # AVHRR Earth location indication of Ascending (=0)
-                     # or descending (=1) data
+               # or descending (=1) data
     PSEUDO_NOISE = 2**7  # Pseudo Noise (P/N) occurred (=1) on the frame,
-                   # data not used for calibration computations
+             # data not used for calibration computations
     BIT_SYNC_STATUS = 2**8  # Drop lock during frame
     SYNC_ERROR = 2**9  # Frame Sync word error greater than zero
     FRAME_SYNC_LOCK = 2**10  # Frame Sync previously dropped lock

--- a/pygac/pod_reader.py
+++ b/pygac/pod_reader.py
@@ -60,15 +60,15 @@ class POD_QualityIndicator(IntFlag):
     # POD guide Table 3.1.2.1-2. Format of quality indicators.
     FATAL_FLAG = 2**0  # Data should not be used for product generation
     TIME_ERROR = 2**1  # A time sequence error was detected while Processing
-     # this frame
+    # this frame
     DATA_GAP = 2**2  # A gap precedes this frame
     DATA_JITTER = 2**3  # Resync occurred on this frame
     CALIBRATION = 2**4  # Insufficient data for calibration
     NO_EARTH_LOCATION = 2**5  # Earth location data not available
     ASCEND_DESCEND = 2**6  # AVHRR Earth location indication of Ascending (=0)
-         # or descending (=1) data
+    # or descending (=1) data
     PSEUDO_NOISE = 2**7  # Pseudo Noise (P/N) occurred (=1) on the frame,
-       # data not used for calibration computations
+    # data not used for calibration computations
     BIT_SYNC_STATUS = 2**8  # Drop lock during frame
     SYNC_ERROR = 2**9  # Frame Sync word error greater than zero
     FRAME_SYNC_LOCK = 2**10  # Frame Sync previously dropped lock

--- a/pygac/pod_reader.py
+++ b/pygac/pod_reader.py
@@ -36,6 +36,11 @@ http://www.ncdc.noaa.gov/oa/pod-guide/ncdc/docs/podug/html/c3/sec3-1.htm
 
 import datetime
 import logging
+try:
+    from enum import IntFlag
+except ImportError:
+    # python version < 3.6
+    from enum import Enum as IntFlag
 
 import numpy as np
 
@@ -44,6 +49,44 @@ from pygac.reader import Reader, ReaderError
 from pygac.utils import file_opener
 
 LOG = logging.getLogger(__name__)
+
+
+class POD_QualityIndicator(IntFlag):
+    """Quality Indicators
+
+    Source:
+        POD guide Table 3.1.2.1-2. Format of quality indicators.
+    """
+    # POD guide Table 3.1.2.1-2. Format of quality indicators.
+    FATAL_FLAG = 2**0  # Data should not be used for product generation
+    TIME_ERROR = 2**1  # A time sequence error was detected while Processing 
+                       # this frame
+    DATA_GAP = 2**2  # A gap precedes this frame
+    DATA_JITTER = 2**3  # Resync occurred on this frame
+    CALIBRATION = 2**4  # Insufficient data for calibration
+    NO_EARTH_LOCATION = 2**5  # Earth location data not available
+    ASCEND_DESCEND = 2**6  # AVHRR Earth location indication of Ascending (=0) 
+                           # or descending (=1) data
+    PSEUDO_NOISE = 2**7  # Pseudo Noise (P/N) occurred (=1) on the frame,
+                         # data not used for calibration computations
+    BIT_SYNC_STATUS = 2**8  # Drop lock during frame
+    SYNC_ERROR = 2**9  # Frame Sync word error greater than zero
+    FRAME_SYNC_LOCK = 2**10  # Frame Sync previously dropped lock
+    FLYWHEELING = 2**11  # Flywheeling detected during this frame
+    BIT_SLIPPAGE = 2**12  # Bit slippage detected during this frame
+    # Solar BlackBody Contamination (SBBC) indicator
+    # 0 = no correction
+    # 1 = solar contamination corrected
+    CH_3_SBBC = 2**13  # Channel 3 solar blackbody contamination
+    CH_4_SBBC = 2**14  # Channel 4 solar blackbody contamination
+    CH_5_SBBC = 2**15  # Channel 4 solar blackbody contamination
+    # TIP Parity
+    TIP_PARITY_1 = 2**16  # In first minor frame
+    TIP_PARITY_2 = 2**17  # In second minor frame
+    TIP_PARITY_3 = 2**18  # In third minor frame
+    TIP_PARITY_4 = 2**19  # In fourth minor frame
+    TIP_PARITY_5 = 2**20  # In fifth minor frame
+
 
 # common header
 header0 = np.dtype([("noaa_spacecraft_identification_code", ">u1"),
@@ -186,6 +229,8 @@ class PODReader(Reader):
                         }
 
     tsm_affected_intervals = TSM_AFFECTED_INTERVALS_POD
+    
+    QFlag = POD_QualityIndicator
 
     def correct_scan_line_numbers(self):
         """Correct the scan line numbers."""

--- a/pygac/pod_reader.py
+++ b/pygac/pod_reader.py
@@ -59,16 +59,16 @@ class POD_QualityIndicator(IntFlag):
     """
     # POD guide Table 3.1.2.1-2. Format of quality indicators.
     FATAL_FLAG = 2**0  # Data should not be used for product generation
-    TIME_ERROR = 2**1  # A time sequence error was detected while Processing 
-                       # this frame
+    TIME_ERROR = 2**1  # A time sequence error was detected while Processing
+                 # this frame
     DATA_GAP = 2**2  # A gap precedes this frame
     DATA_JITTER = 2**3  # Resync occurred on this frame
     CALIBRATION = 2**4  # Insufficient data for calibration
     NO_EARTH_LOCATION = 2**5  # Earth location data not available
-    ASCEND_DESCEND = 2**6  # AVHRR Earth location indication of Ascending (=0) 
-                           # or descending (=1) data
+    ASCEND_DESCEND = 2**6  # AVHRR Earth location indication of Ascending (=0)
+                     # or descending (=1) data
     PSEUDO_NOISE = 2**7  # Pseudo Noise (P/N) occurred (=1) on the frame,
-                         # data not used for calibration computations
+                   # data not used for calibration computations
     BIT_SYNC_STATUS = 2**8  # Drop lock during frame
     SYNC_ERROR = 2**9  # Frame Sync word error greater than zero
     FRAME_SYNC_LOCK = 2**10  # Frame Sync previously dropped lock
@@ -229,7 +229,7 @@ class PODReader(Reader):
                         }
 
     tsm_affected_intervals = TSM_AFFECTED_INTERVALS_POD
-    
+
     QFlag = POD_QualityIndicator
 
     def correct_scan_line_numbers(self):

--- a/pygac/pod_reader.py
+++ b/pygac/pod_reader.py
@@ -52,7 +52,7 @@ LOG = logging.getLogger(__name__)
 
 
 class POD_QualityIndicator(IntFlag):
-    """Quality Indicators
+    """Quality Indicators.
 
     Source:
         POD guide Table 3.1.2.1-2. Format of quality indicators.
@@ -86,6 +86,8 @@ class POD_QualityIndicator(IntFlag):
     TIP_PARITY_3 = 2**18  # In third minor frame
     TIP_PARITY_4 = 2**19  # In fourth minor frame
     TIP_PARITY_5 = 2**20  # In fifth minor frame
+    # Note: 2**21 to 2**23, and 2**30 to 2**31 are spare bits. 2**24 to 2**29 define
+    #       "SYNC ERRORS - Number of bit errors in frame sync" (6 bit integer?)
 
 
 # common header

--- a/pygac/pod_reader.py
+++ b/pygac/pod_reader.py
@@ -60,15 +60,15 @@ class POD_QualityIndicator(IntFlag):
     # POD guide Table 3.1.2.1-2. Format of quality indicators.
     FATAL_FLAG = 2**0  # Data should not be used for product generation
     TIME_ERROR = 2**1  # A time sequence error was detected while Processing
-           # this frame
+     # this frame
     DATA_GAP = 2**2  # A gap precedes this frame
     DATA_JITTER = 2**3  # Resync occurred on this frame
     CALIBRATION = 2**4  # Insufficient data for calibration
     NO_EARTH_LOCATION = 2**5  # Earth location data not available
     ASCEND_DESCEND = 2**6  # AVHRR Earth location indication of Ascending (=0)
-               # or descending (=1) data
+         # or descending (=1) data
     PSEUDO_NOISE = 2**7  # Pseudo Noise (P/N) occurred (=1) on the frame,
-             # data not used for calibration computations
+       # data not used for calibration computations
     BIT_SYNC_STATUS = 2**8  # Drop lock during frame
     SYNC_ERROR = 2**9  # Frame Sync word error greater than zero
     FRAME_SYNC_LOCK = 2**10  # Frame Sync previously dropped lock

--- a/pygac/reader.py
+++ b/pygac/reader.py
@@ -642,10 +642,21 @@ class Reader(six.with_metaclass(ABCMeta)):
             self._mask = self._get_corrupt_mask()
         return self._mask
 
-    @abstractmethod
-    def _get_corrupt_mask(self):
-        """KLM/POD specific readout of corrupt scanline mask."""
-        raise NotImplementedError
+    def _get_corrupt_mask(self, flags=None):
+        """Readout of corrupt scanline mask.
+
+        Args:
+            flags (QFlag.flag): An "ORed" bitmask that defines corrupt values.
+                                Defauts to (QFlag.FATAL_FLAG | QFlag.CALIBRATION
+                                | QFlag.NO_EARTH_LOCATION)
+
+        Note:
+            The Quality flags mapping (QFlag) is KLM/POD specific.
+        """
+        QFlag = self.QFlag
+        if flags is None:
+            flags = QFlag.FATAL_FLAG | QFlag.CALIBRATION | QFlag.NO_EARTH_LOCATION
+        return (self.scans['quality_indicators'] & flags.value).astype(bool)
 
     @abstractmethod
     def postproc(self, channels):

--- a/pygac/reader.py
+++ b/pygac/reader.py
@@ -656,7 +656,20 @@ class Reader(six.with_metaclass(ABCMeta)):
         QFlag = self.QFlag
         if flags is None:
             flags = QFlag.FATAL_FLAG | QFlag.CALIBRATION | QFlag.NO_EARTH_LOCATION
-        return (self.scans['quality_indicators'] & flags.value).astype(bool)
+        return (self.scans['quality_indicators'] & int(flags)).astype(bool)
+
+    def get_qual_flags(self):
+        """Read quality flags."""
+        number_of_scans = self.scans["telemetry"].shape[0]
+        qual_flags = np.zeros((int(number_of_scans), 7))
+        qual_flags[:, 0] = self.scans["scan_line_number"]
+        qual_flags[:, 1] = self._get_corrupt_mask(flags=self.Qflag.FATAL_FLAG)
+        qual_flags[:, 2] = self._get_corrupt_mask(flags=self.Qflag.CALIBRATION)
+        qual_flags[:, 3] = self._get_corrupt_mask(flags=self.Qflag.NO_EARTH_LOCATION)
+        qual_flags[:, 4] = self._get_corrupt_mask(flags=self.Qflag.CH_3_CONTAMINATION)
+        qual_flags[:, 5] = self._get_corrupt_mask(flags=self.Qflag.CH_4_CONTAMINATION)
+        qual_flags[:, 6] = self._get_corrupt_mask(flags=self.Qflag.CH_5_CONTAMINATION)
+        return qual_flags
 
     @abstractmethod
     def postproc(self, channels):

--- a/pygac/reader.py
+++ b/pygac/reader.py
@@ -656,19 +656,19 @@ class Reader(six.with_metaclass(ABCMeta)):
         QFlag = self.QFlag
         if flags is None:
             flags = QFlag.FATAL_FLAG | QFlag.CALIBRATION | QFlag.NO_EARTH_LOCATION
-        return (self.scans['quality_indicators'] & int(flags)).astype(bool)
+        return (self.scans[self._quality_indicators_key] & int(flags)).astype(bool)
 
     def get_qual_flags(self):
         """Read quality flags."""
         number_of_scans = self.scans["telemetry"].shape[0]
         qual_flags = np.zeros((int(number_of_scans), 7))
         qual_flags[:, 0] = self.scans["scan_line_number"]
-        qual_flags[:, 1] = self._get_corrupt_mask(flags=self.Qflag.FATAL_FLAG)
-        qual_flags[:, 2] = self._get_corrupt_mask(flags=self.Qflag.CALIBRATION)
-        qual_flags[:, 3] = self._get_corrupt_mask(flags=self.Qflag.NO_EARTH_LOCATION)
-        qual_flags[:, 4] = self._get_corrupt_mask(flags=self.Qflag.CH_3_CONTAMINATION)
-        qual_flags[:, 5] = self._get_corrupt_mask(flags=self.Qflag.CH_4_CONTAMINATION)
-        qual_flags[:, 6] = self._get_corrupt_mask(flags=self.Qflag.CH_5_CONTAMINATION)
+        qual_flags[:, 1] = self._get_corrupt_mask(flags=self.QFlag.FATAL_FLAG)
+        qual_flags[:, 2] = self._get_corrupt_mask(flags=self.QFlag.CALIBRATION)
+        qual_flags[:, 3] = self._get_corrupt_mask(flags=self.QFlag.NO_EARTH_LOCATION)
+        qual_flags[:, 4] = self._get_corrupt_mask(flags=self.QFlag.CH_3_CONTAMINATION)
+        qual_flags[:, 5] = self._get_corrupt_mask(flags=self.QFlag.CH_4_CONTAMINATION)
+        qual_flags[:, 6] = self._get_corrupt_mask(flags=self.QFlag.CH_5_CONTAMINATION)
         return qual_flags
 
     @abstractmethod

--- a/pygac/tests/test_pod.py
+++ b/pygac/tests/test_pod.py
@@ -148,6 +148,26 @@ class TestPOD(unittest.TestCase):
                                        CalledWithArray(ch4),
                                        CalledWithArray(ch5))
 
+    def test_quality_indicators(self):
+        """Test the quality indicator unpacking."""
+        reader = self.reader
+        QFlag = reader.QFlag
+        quality_indicators = np.array([
+            0,  # nothing flagged
+            -1,  # everything flagged
+            QFlag.CALIBRATION | QFlag.NO_EARTH_LOCATION,
+            QFlag.TIME_ERROR | QFlag.DATA_GAP,
+            QFlag.FATAL_FLAG
+        ], dtype=np.uint32)
+        reader.scans = {self.reader._quality_indicators_key: quality_indicators}
+        # test mask, i.e. QFlag.FATAL_FLAG | QFlag.CALIBRATION | QFlag.NO_EARTH_LOCATION
+        expected_mask = np.array([False, True, True, False, True], dtype=bool)
+        numpy.testing.assert_array_equal(reader.mask, expected_mask)
+        # test individual flags
+        self.assertTrue(reader._get_corrupt_mask(flags=QFlag.FATAL_FLAG).any())
+        # count the occurence (everything flagged and last entrance => 2)
+        self.assertEqual(reader._get_corrupt_mask(flags=QFlag.FATAL_FLAG).sum(), 2)
+
 
 def suite():
     """Test suite for test_pod."""


### PR DESCRIPTION
This PR should close #60. 

It implements the quality indicator mapping as `enum.IntFlag` for KLM and POD readers and moves the methods `reader._get_corrupt_mask` and `get_qual_flags` to the parent class.
