### PR TITLE
Fix tests on bigendian platforms

### DIFF
--- a/pygac/tests/test_reader.py
+++ b/pygac/tests/test_reader.py
@@ -60,7 +60,7 @@ class TestGacReader(unittest.TestCase):
     def test__read_scanlines(self):
         """Test the scanline extraction."""
         self.reader.scanline_type = np.dtype([
-            ('a', 'S2'), ('b', 'i4')])
+            ('a', 'S2'), ('b', '<i4')])
         # request more scan lines than available
         with self.assertWarnsRegex(RuntimeWarning,
                                    "Unexpected number of scanlines!"):


### PR DESCRIPTION
This PR fixes a test failure on Bug Endian platforms that we discovered building the debian package for pygac (see [1]).

The issue seems to be in the test code, not in the library.

[1] https://buildd.debian.org/status/fetch.php?pkg=pygac&arch=s390x&ver=1.4.0-1&stamp=1596978522&raw=0

The PR is marked as WIP because the fix is till under test. We will give an acknowledgement once the test completes

Edit: 
Tests on s390x completed successfully.