### PR TITLE
Allow PathLike objects

### DIFF
--- a/.stickler.yml
+++ b/.stickler.yml
@@ -1,6 +1,7 @@
 linters:
   flake8:
     fixer: true
-    max-line-length: 120
+    python: 3
+    config: setup.cfg
 fixers:
   enable: true

--- a/pygac/reader.py
+++ b/pygac/reader.py
@@ -142,6 +142,7 @@ class Reader(six.with_metaclass(ABCMeta)):
         if filepath is None:
             self._filename = None
         else:
+            filepath = os.fspath(filepath)
             match = self.data_set_pattern.search(filepath)
             if match:
                 self._filename = match.group()

--- a/pygac/tests/test_reader.py
+++ b/pygac/tests/test_reader.py
@@ -23,6 +23,7 @@
 import datetime
 import unittest
 import sys
+import os
 try:
     import mock
 except ImportError:
@@ -54,6 +55,15 @@ class TestGacReader(unittest.TestCase):
         filename = 'NSS.GHRR.TN.D80001.S0332.E0526.B0627173.WI'
         filepath = '/path/to/' + filename + '.gz'
         self.reader.filename = filepath
+        self.assertEqual(self.reader.filename, filename)
+        self.reader.filename = None
+        self.assertIsNone(self.reader.filename)
+        class TestPath(os.PathLike):
+            def __init__(self, path):
+                self.path = str(path)
+            def __fspath__(self):
+                return self.path
+        self.reader.filename = TestPath(filepath)
         self.assertEqual(self.reader.filename, filename)
 
     @unittest.skipIf(sys.version_info.major < 3, "Skipped in python2!")

--- a/pygac/tests/test_reader.py
+++ b/pygac/tests/test_reader.py
@@ -58,9 +58,11 @@ class TestGacReader(unittest.TestCase):
         self.assertEqual(self.reader.filename, filename)
         self.reader.filename = None
         self.assertIsNone(self.reader.filename)
+
         class TestPath(os.PathLike):
             def __init__(self, path):
                 self.path = str(path)
+
             def __fspath__(self):
                 return self.path
         self.reader.filename = TestPath(filepath)

--- a/pygac/tests/test_utils.py
+++ b/pygac/tests/test_utils.py
@@ -39,13 +39,12 @@ class TestUtils(unittest.TestCase):
 
     longMessage = True
 
-    @mock.patch('pygac.utils.open', mock.mock_open(read_data='file content'))
-    @mock.patch('pygac.utils.gzip.open', mock.MagicMock(side_effect=OSError))
+    @mock.patch('pygac.utils.open', mock.MagicMock(return_value=io.BytesIO(b'file content')))
     def test_file_opener_1(self):
         """Test if a file is redirected correctly through file_opener."""
         with file_opener('path/to/file') as f:
             content = f.read()
-        self.assertEqual(content, 'file content')
+        self.assertEqual(content, b'file content')
 
     def test_file_opener_2(self):
         """Test file_opener with file objects and compression"""
@@ -70,7 +69,6 @@ class TestUtils(unittest.TestCase):
         self.assertEqual(message, gzip_message_decoded)
 
     @mock.patch('pygac.utils.open', mock.MagicMock(side_effect=FileNotFoundError))
-    @mock.patch('pygac.utils.gzip.open', mock.MagicMock(side_effect=OSError))
     def test_file_opener_3(self):
         """Test file_opener with PathLike object"""
         # prepare test

--- a/pygac/tests/test_utils.py
+++ b/pygac/tests/test_utils.py
@@ -34,35 +34,13 @@ try:
 except ImportError:
     import mock
 
-from pygac.utils import (is_file_object, file_opener,
-                         calculate_sun_earth_distance_correction)
+from pygac.utils import file_opener, calculate_sun_earth_distance_correction
 
 
 class TestUtils(unittest.TestCase):
     """Test pygac.utils functions"""
 
     longMessage = True
-
-    def test_is_file_object(self):
-        """Test is_file_object function."""
-        # true test
-        with io.BytesIO(b'file content') as fileobj:
-            self.assertTrue(is_file_object(fileobj))
-        # false test
-        self.assertFalse(is_file_object("test.txt"))
-        # duck type test
-
-        class Duck(object):
-            def read(self, n):
-                return n*b'\00'
-
-            def seekable(self):
-                return True
-
-            def close(self):
-                pass
-        duck = Duck()
-        self.assertTrue(is_file_object(duck))
 
     @mock.patch('pygac.utils.open', mock.mock_open(read_data='file content'))
     @mock.patch('pygac.utils.gzip.open', mock.MagicMock(side_effect=OSError))
@@ -72,7 +50,6 @@ class TestUtils(unittest.TestCase):
             content = f.read()
         self.assertEqual(content, 'file content')
 
-    @unittest.skipIf(sys.version_info.major < 3, "Not supported in python2!")
     def test_file_opener_2(self):
         """Test file_opener with file objects and compression"""
         # prepare test
@@ -95,7 +72,6 @@ class TestUtils(unittest.TestCase):
                 message = g.read()
         self.assertEqual(message, gzip_message_decoded)
 
-    @unittest.skipIf(sys.version_info.major < 3, "Not supported in python2!")
     @mock.patch('pygac.utils.open', mock.MagicMock(side_effect=FileNotFoundError))
     @mock.patch('pygac.utils.gzip.open', mock.MagicMock(side_effect=OSError))
     def test_file_opener_3(self):

--- a/pygac/tests/test_utils.py
+++ b/pygac/tests/test_utils.py
@@ -23,16 +23,13 @@
 """Test pygac.utils module
 """
 
-import unittest
-import io
 import gzip
-import sys
-import numpy as np
+import io
 import os
-try:
-    from unittest import mock
-except ImportError:
-    import mock
+import unittest
+from unittest import mock
+
+import numpy as np
 
 from pygac.utils import file_opener, calculate_sun_earth_distance_correction
 

--- a/pygac/tests/test_utils.py
+++ b/pygac/tests/test_utils.py
@@ -118,14 +118,14 @@ class TestUtils(unittest.TestCase):
         with file_opener(test_pathlike) as f:
             content = f.read()
         self.assertEqual(content, file_bytes)
-        
+
         # test with lazy loading open method (open only in context)
         class RawBytesLazy(RawBytes):
             def open(self):
                 self.lazy_opener_mock = mock.MagicMock()
                 self.lazy_opener_mock.__enter__.return_value = io.BytesIO(self.raw_bytes)
                 return self.lazy_opener_mock
-            
+
         test_pathlike = RawBytesLazy(filename, file_bytes)
         with file_opener(test_pathlike) as f:
             content = f.read()

--- a/pygac/utils.py
+++ b/pygac/utils.py
@@ -22,7 +22,6 @@
 import gzip
 import io
 import logging
-import sys
 
 from contextlib import contextmanager, nullcontext
 

--- a/pygac/utils.py
+++ b/pygac/utils.py
@@ -34,7 +34,7 @@ def gzip_inspected(open_file):
     """Try to gzip decompress the file object if applicable."""
     try:
         file_object = gzip.GzipFile(mode='rb', fileobj=open_file)
-        file_object.read1()
+        file_object.read(1)
     except OSError:
         file_object = open_file
     finally:
@@ -54,7 +54,7 @@ def file_opener(file):
             open_file = file.open()
     else:
         open_file = open(file, mode='rb')
-    # set open_file into context in case of lazy loding in __enter__ method.
+    # set open_file into context in case of lazy loading in __enter__ method.
     with open_file as file_object:
         yield gzip_inspected(file_object)
 

--- a/pygac/utils.py
+++ b/pygac/utils.py
@@ -55,10 +55,17 @@ def _file_opener(file):
     Args:
         file - path to file or file object
     """
+    close = False
     # open file if necessary
     if is_file_object(file):
         open_file = file
-        close = False
+    elif hasattr(file, 'open'):
+        # use __enter__ to set the fileobject into context, this
+        # is needed to access the actual file object in fsspec
+        try:
+            open_file = file.open(mode='rb').__enter__()
+        except TypeError:
+            open_file = file.open().__enter__()
     else:
         open_file = open(file, mode='rb')
         close = True

--- a/pygac/utils.py
+++ b/pygac/utils.py
@@ -33,13 +33,14 @@ LOG = logging.getLogger(__name__)
 def gzip_inspected(open_file):
     """Try to gzip decompress the file object if applicable."""
     try:
-        file_object = gzip.open(open_file)
-        file_object.read(1)
+        file_object = gzip.GzipFile(mode='rb', fileobj=open_file)
+        file_object.read1()
     except OSError:
         file_object = open_file
     finally:
         file_object.seek(0)
     return file_object
+
 
 @contextmanager
 def file_opener(file):
@@ -56,6 +57,7 @@ def file_opener(file):
     # set open_file into context in case of lazy loding in __enter__ method.
     with open_file as file_object:
         yield gzip_inspected(file_object)
+
 
 def get_absolute_azimuth_angle_diff(sat_azi, sun_azi):
     """Calculates absolute azimuth difference angle. """

--- a/pygac/utils.py
+++ b/pygac/utils.py
@@ -20,59 +20,19 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import gzip
+import io
 import logging
-import numpy as np
 import sys
-from contextlib import contextmanager
+
+from contextlib import contextmanager, nullcontext
+
+import numpy as np
 
 LOG = logging.getLogger(__name__)
 
 
-def is_file_object(filename):
-    """Check if the input is a file object.
-
-    Args:
-        filename - object to check
-
-    Note:
-        This method only check if the object implements the
-        interface of a file object to allow duck types like
-        gzip.GzipFile instances.
-    """
-    has_close = hasattr(filename, 'close')
-    has_read = hasattr(filename, 'read')
-    if hasattr(filename, 'seekable'):
-        is_seekable = filename.seekable()
-    else:
-        is_seekable = False
-    return has_close and has_read and is_seekable
-
-
-@contextmanager
-def _file_opener(file):
-    """Open a file depending on the input.
-
-    Args:
-        file - path to file or file object
-    """
-    close = False
-    exit = False
-    # open file if necessary
-    if is_file_object(file):
-        open_file = file
-    elif hasattr(file, 'open'):
-        try:
-            _open_file = file.open(mode='rb')
-        except TypeError:
-            _open_file = file.open()
-        # use __enter__ to set the fileobject into context, this
-        # is needed to access the actual file object in fsspec
-        open_file = _open_file.__enter__()
-        exit = True
-    else:
-        open_file = open(file, mode='rb')
-        close = True
-    # check if it is a gzip file
+def gzip_inspected(open_file):
+    """Try to gzip decompress the file object if applicable."""
     try:
         file_object = gzip.open(open_file)
         file_object.read(1)
@@ -80,53 +40,23 @@ def _file_opener(file):
         file_object = open_file
     finally:
         file_object.seek(0)
-    # provide file_object with the context
-    try:
-        yield file_object
-    finally:
-        if close:
-            open_file.close()
-        if exit:
-            _open_file.__exit__(None, None, None)
-
+    return file_object
 
 @contextmanager
-def _file_opener_py2(file):
-    """Open a file depending on the input.
-
-    Args:
-        file - path to file
-    """
-    close = True
-    # check if it is a gzip file
-    try:
-        file_object = gzip.open(file)
-        file_object.read(1)
-    # Note: in python 2, this is an IOError, but we keep the
-    #       OSError for testing.
-    except (OSError, IOError):
-        file_object = open(file, mode='rb')
-    except TypeError:
-        # In python 2 gzip.open cannot handle file objects
-        LOG.debug("Gzip cannot open file objects in python2!")
-        if is_file_object(file):
-            file_object = file
-            close = False
-    finally:
-        file_object.seek(0)
-    # provide file_object with the context
-    try:
-        yield file_object
-    finally:
-        if close:
-            file_object.close()
-
-
-if sys.version_info.major < 3:
-    file_opener = _file_opener_py2
-else:
-    file_opener = _file_opener
-
+def file_opener(file):
+    if isinstance(file, io.IOBase) and file.seekable():
+        # avoid closing the file using nullcontext
+        open_file = nullcontext(file)
+    elif hasattr(file, 'open'):
+        try:
+            open_file = file.open(mode='rb')
+        except TypeError:
+            open_file = file.open()
+    else:
+        open_file = open(file, mode='rb')
+    # set open_file into context in case of lazy loding in __enter__ method.
+    with open_file as file_object:
+        yield gzip_inspected(file_object)
 
 def get_absolute_azimuth_angle_diff(sat_azi, sun_azi):
     """Calculates absolute azimuth difference angle. """

--- a/setup.py
+++ b/setup.py
@@ -74,6 +74,6 @@ if __name__ == '__main__':
                       ('gapfilled_tles', ['gapfilled_tles/TLE_noaa16.txt'])],
           test_suite="pygac.tests.suite",
           tests_require=[],
-          python_requires='>=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*',
+          python_requires='>=3.6',
           zip_safe=False
           )


### PR DESCRIPTION
This PR allows *pygac* to open `PathLike` objects, that provide an `open` method.
This is motivated by the new *satpy* feature from https://github.com/pytroll/satpy/pull/1439 and the subsequent PR https://github.com/pytroll/satpy/pull/1470, where @sfinkens asked to move the implementation to *pygac*.