### PR TITLE
Fix clockdrift adjustment in case of missing TLEs

### DIFF
--- a/pygac/pod_reader.py
+++ b/pygac/pod_reader.py
@@ -49,7 +49,7 @@ from pyorbital.geoloc import compute_pixels, get_lonlatalt
 
 from pygac.clock_offsets_converter import get_offsets
 from pygac.correct_tsm_issue import TSM_AFFECTED_INTERVALS_POD, get_tsm_idx
-from pygac.reader import Reader, ReaderError
+from pygac.reader import Reader, ReaderError, NoTLEData
 from pygac.slerp import slerp
 from pygac.utils import file_opener
 
@@ -484,7 +484,11 @@ class PODReader(Reader):
         missed_utcs = ((missed_lines - scan_lines[0])*np.timedelta64(scan_rate, "ms")
                        + self.utcs[0])
         # calculate the missing geo locations
-        missed_lons, missed_lats = self._compute_missing_lonlat(missed_utcs)
+        try:
+            missed_lons, missed_lats = self._compute_missing_lonlat(missed_utcs)
+        except NoTLEData as err:
+            LOG.warning('Cannot perform clock drift correction: %s', str(err))
+            return
 
         # create arrays of lons and lats for interpolation. The locations
         # correspond to not yet corrected utcs, i.e. the time difference from

--- a/pygac/reader.py
+++ b/pygac/reader.py
@@ -720,6 +720,10 @@ class Reader(six.with_metaclass(ABCMeta)):
         try:
             return self._get_sat_angles_with_tle()
         except NoTLEData:
+            LOG.warning(
+                'No TLE data available. Falling back to approximate '
+                'calculation of satellite angles.'
+            )
             return self._get_sat_angles_without_tle()
 
     def _get_sat_angles_with_tle(self):

--- a/pygac/reader.py
+++ b/pygac/reader.py
@@ -82,7 +82,6 @@ class ReaderError(ValueError):
 
 class NoTLEData(IndexError):
     """Raised if no TLE data available within time range."""
-    pass
 
 
 class Reader(six.with_metaclass(ABCMeta)):

--- a/pygac/reader.py
+++ b/pygac/reader.py
@@ -80,6 +80,11 @@ class ReaderError(ValueError):
     pass
 
 
+class NoTLEData(IndexError):
+    """Raised if no TLE data available within time range."""
+    pass
+
+
 class Reader(six.with_metaclass(ABCMeta)):
     """Reader for Gac and Lac, POD and KLM data."""
 
@@ -690,7 +695,7 @@ class Reader(six.with_metaclass(ABCMeta)):
         # Make sure the TLE we found is within the threshold
         delta_days = abs(sdate - dates[iindex]) / np.timedelta64(1, 'D')
         if delta_days > self.tle_thresh:
-            raise IndexError(
+            raise NoTLEData(
                 "Can't find tle data for %s within +/- %d days around %s" %
                 (self.spacecraft_name, self.tle_thresh, sdate))
 
@@ -707,7 +712,26 @@ class Reader(six.with_metaclass(ABCMeta)):
         self.tle_lines = tle1, tle2
         return tle1, tle2
 
-    def get_sat_angles_without_tle(self):
+    def get_sat_angles(self):
+        """Get satellite angles.
+
+        Returns:
+            Azimuth, elevation (degrees)
+        """
+        try:
+            return self._get_sat_angles_with_tle()
+        except NoTLEData:
+            return self._get_sat_angles_without_tle()
+
+    def _get_sat_angles_with_tle(self):
+        tle1, tle2 = self.get_tle_lines()
+        orb = Orbital(self.spacecrafts_orbital[self.spacecraft_id],
+                      line1=tle1, line2=tle2)
+        sat_azi, sat_elev = orb.get_observer_look(self.times[:, np.newaxis],
+                                                  self.lons, self.lats, 0)
+        return sat_azi, sat_elev
+
+    def _get_sat_angles_without_tle(self):
         """Get satellite angles using lat/lon from data to approximate satellite postition instead of TLE."""
         from pyorbital.orbital import get_observer_look as get_observer_look_no_tle
         LOG.warning('Approximating satellite height to 850km (TIROS-N OSCAR)!')
@@ -746,14 +770,7 @@ class Reader(six.with_metaclass(ABCMeta)):
         self.get_times()
         self.get_lonlat()
         times = self.times
-        try:
-            tle1, tle2 = self.get_tle_lines()
-            orb = Orbital(self.spacecrafts_orbital[self.spacecraft_id],
-                          line1=tle1, line2=tle2)
-            sat_azi, sat_elev = orb.get_observer_look(times[:, np.newaxis],
-                                                      self.lons, self.lats, 0)
-        except IndexError:
-            sat_azi, sat_elev = self.get_sat_angles_without_tle()
+        sat_azi, sat_elev = self.get_sat_angles()
 
         sat_zenith = 90 - sat_elev
         sun_zenith = astronomy.sun_zenith_angle(times[:, np.newaxis],

--- a/pygac/tests/test_pod.py
+++ b/pygac/tests/test_pod.py
@@ -284,15 +284,15 @@ class TestPOD(unittest.TestCase):
         # undo changes to clock_offsets_txt
         clock_offsets_txt.pop(sat_name)
 
-    @mock.patch('pygac.clock_offsets_converter.get_offsets')
+    @mock.patch('pygac.pod_reader.get_offsets')
     @mock.patch('pygac.reader.Reader.get_tle_lines')
-    def test__adjust_clock_drift_without_tle(self, get_offsets, get_tle_lines):
+    def test__adjust_clock_drift_without_tle(self, get_tle_lines, get_offsets):
         """Test that clockdrift adjustment can handle missing TLE data."""
         reader = self.reader
         reader.utcs = np.zeros(10, dtype='datetime64[ms]')
         reader.scans = {"scan_line_number": np.arange(10)}
         get_offsets.return_value = np.zeros(10), np.zeros(10)
-        get_tle_lines.side_effect = NoTLEData('foo')
+        get_tle_lines.side_effect = NoTLEData('No TLE data available')
         reader._adjust_clock_drift()  # should pass without errors
 
 

--- a/pygac/tests/test_pod.py
+++ b/pygac/tests/test_pod.py
@@ -31,7 +31,7 @@ except ImportError:
     import mock
 
 from pygac.clock_offsets_converter import txt as clock_offsets_txt
-from pygac.reader import ReaderError
+from pygac.reader import ReaderError, NoTLEData
 from pygac.gac_pod import GACPODReader
 from pygac.lac_pod import LACPODReader
 from pygac.tests.utils import CalledWithArray
@@ -283,6 +283,18 @@ class TestPOD(unittest.TestCase):
 
         # undo changes to clock_offsets_txt
         clock_offsets_txt.pop(sat_name)
+
+    @mock.patch('pygac.clock_offsets_converter.get_offsets')
+    @mock.patch('pygac.reader.Reader.get_tle_lines')
+    def test__adjust_clock_drift_without_tle(self, get_offsets, get_tle_lines):
+        """Test that clockdrift adjustment can handle missing TLE data."""
+        reader = self.reader
+        reader.utcs = np.zeros(10, dtype='datetime64[ms]')
+        reader.scans = {"scan_line_number": np.arange(10)}
+        get_offsets.return_value = np.zeros(10), np.zeros(10)
+        get_tle_lines.side_effect = NoTLEData('foo')
+        reader._adjust_clock_drift()  # should pass without errors
+
 
 def suite():
     """Test suite for test_pod."""


### PR DESCRIPTION
Closes #94 by restoring the try...except block that was removed in 3f0430687. Also tried to make the handling of that exception a bit more self-explanatory.