### PR TITLE
Fix reading of path like objects

### DIFF
--- a/pygac/reader.py
+++ b/pygac/reader.py
@@ -206,7 +206,7 @@ class Reader(six.with_metaclass(ABCMeta)):
         if not cls.data_set_pattern.match(data_set_name):
             LOG.debug('The data_set_name in header %s does not match.'
                       ' Use filename instead.' % header['data_set_name'])
-            match = cls.data_set_pattern.search(filename)
+            match = cls.data_set_pattern.search(str(filename))
             if match:
                 data_set_name = match.group()
                 LOG.debug("Set data_set_name, to filename %s"

--- a/pygac/reader.py
+++ b/pygac/reader.py
@@ -214,7 +214,7 @@ class Reader(six.with_metaclass(ABCMeta)):
                 header['data_set_name'] = data_set_name.encode()
             else:
                 LOG.debug("header['data_set_name']=%s; filename='%s'"
-                          % (header['data_set_name'], filename))
+                          % (header['data_set_name'], str(filename)))
                 raise ReaderError('Cannot determine data_set_name!')
         return header
 

--- a/pygac/reader.py
+++ b/pygac/reader.py
@@ -202,11 +202,12 @@ class Reader(six.with_metaclass(ABCMeta)):
             header (struct): file header
             filename (str): path to file
         """
+        filename = str(filename)
         data_set_name = header['data_set_name'].decode(errors='ignore')
         if not cls.data_set_pattern.match(data_set_name):
             LOG.debug('The data_set_name in header %s does not match.'
                       ' Use filename instead.' % header['data_set_name'])
-            match = cls.data_set_pattern.search(str(filename))
+            match = cls.data_set_pattern.search(filename)
             if match:
                 data_set_name = match.group()
                 LOG.debug("Set data_set_name, to filename %s"
@@ -214,7 +215,7 @@ class Reader(six.with_metaclass(ABCMeta)):
                 header['data_set_name'] = data_set_name.encode()
             else:
                 LOG.debug("header['data_set_name']=%s; filename='%s'"
-                          % (header['data_set_name'], str(filename)))
+                          % (header['data_set_name'], filename))
                 raise ReaderError('Cannot determine data_set_name!')
         return header
 

--- a/pygac/tests/test_reader.py
+++ b/pygac/tests/test_reader.py
@@ -126,7 +126,7 @@ class TestGacReader(unittest.TestCase):
         from satpy.readers import FSFile
         FS_filepath = FSFile(val_filepath)
         head = self.reader._correct_data_set_name(val_head.copy(), FS_filepath)
-        self.assertEqual(head['data_set_name'], val_filename.encode())        
+        self.assertEqual(head['data_set_name'], val_filename.encode())
 
     @mock.patch('pygac.reader.Reader.get_calibrated_channels')
     def test__get_calibrated_channels_uniform_shape(self, get_channels):

--- a/pygac/tests/test_reader.py
+++ b/pygac/tests/test_reader.py
@@ -34,6 +34,14 @@ from pygac.gac_reader import GACReader, ReaderError
 from pygac.reader import NoTLEData
 
 
+class TestPath(os.PathLike):
+    def __init__(self, path):
+        self.path = str(path)
+
+    def __fspath__(self):
+        return self.path
+
+
 class TestGacReader(unittest.TestCase):
     """Test the common GAC Reader."""
 
@@ -59,13 +67,6 @@ class TestGacReader(unittest.TestCase):
         self.assertEqual(self.reader.filename, filename)
         self.reader.filename = None
         self.assertIsNone(self.reader.filename)
-
-        class TestPath(os.PathLike):
-            def __init__(self, path):
-                self.path = str(path)
-
-            def __fspath__(self):
-                return self.path
         self.reader.filename = TestPath(filepath)
         self.assertEqual(self.reader.filename, filename)
 
@@ -123,9 +124,8 @@ class TestGacReader(unittest.TestCase):
         head = self.reader._correct_data_set_name(val_head.copy(), inv_filepath)
         self.assertEqual(head['data_set_name'], val_head['data_set_name'])
         # enter a valid data_set_name, and an FSFile/pathlib object as filepath
-        from satpy.readers import FSFile
-        FS_filepath = FSFile(val_filepath)
-        head = self.reader._correct_data_set_name(val_head.copy(), FS_filepath)
+        fs_filepath = TestPath(val_filepath)
+        head = self.reader._correct_data_set_name(val_head.copy(), fs_filepath)
         self.assertEqual(head['data_set_name'], val_filename.encode())
 
     @mock.patch('pygac.reader.Reader.get_calibrated_channels')

--- a/pygac/tests/test_reader.py
+++ b/pygac/tests/test_reader.py
@@ -122,6 +122,11 @@ class TestGacReader(unittest.TestCase):
         # should be fine, because the data_set_name is the pefered source
         head = self.reader._correct_data_set_name(val_head.copy(), inv_filepath)
         self.assertEqual(head['data_set_name'], val_head['data_set_name'])
+        # enter a valid data_set_name, and an FSFile/pathlib object as filepath
+        from satpy.readers import FSFile
+        FS_filepath = FSFile(val_filepath)
+        head = self.reader._correct_data_set_name(val_head.copy(), FS_filepath)
+        self.assertEqual(head['data_set_name'], val_filename.encode())        
 
     @mock.patch('pygac.reader.Reader.get_calibrated_channels')
     def test__get_calibrated_channels_uniform_shape(self, get_channels):


### PR DESCRIPTION
The regular expression matching requires a string as input, not a file system object.