### PR TITLE
replacing median with 50th percentile

### DIFF
--- a/pygac/reader.py
+++ b/pygac/reader.py
@@ -817,7 +817,7 @@ class Reader(six.with_metaclass(ABCMeta)):
         msec_lineno = self.lineno2msec(self.scans["scan_line_number"])
 
         jday = np.where(np.logical_or(jday < 1, jday > 366),
-                        np.median(jday), jday)
+                        np.percentile(jday, 50, interpolation='nearest'), jday)
         if_wrong_jday = np.ediff1d(jday, to_begin=0)
         jday = np.where(if_wrong_jday < 0, max(jday), jday)
 
@@ -827,7 +827,7 @@ class Reader(six.with_metaclass(ABCMeta)):
             if if_wrong_msec[0] != 0:
                 msec = msec[0] + msec_lineno
             else:
-                msec0 = np.median(msec - msec_lineno)
+                msec0 = np.percentile(msec - msec_lineno, 50, interpolation='nearest')
                 msec = msec0 + msec_lineno
 
         if_wrong_msec = np.ediff1d(msec, to_begin=0)
@@ -846,9 +846,9 @@ class Reader(six.with_metaclass(ABCMeta)):
                 msec = msec[0] + msec_lineno
             # Otherwise use median time stamp
             else:
-                year = np.median(year)
-                jday = np.median(jday)
-                msec0 = np.median(msec - msec_lineno)
+                year = np.percentile(year, 50, interpolation='nearest')
+                jday = np.percentile(jday, 50, interpolation='nearest')
+                msec0 = np.percentile(msec - msec_lineno, 50, interpolation='nearest')
                 msec = msec0 + msec_lineno
 
         return year, jday, msec


### PR DESCRIPTION
Method `correct_times_median` should provide median values for year, doy, and milliseconds to correct invalid timestamps. However, `np.median` will return floats, which could even be fractions due to `np.median`'s internal interpolation method of the two closest values. I'd suggest to use `np.percentile` instead, where one can explicitly set the interpolation method. Setting this to "nearest" will always return the value closest to the statistical median, thus not changing its type.

`np.median([1, 2, 3, 4, 5, 6])`
returns 3.5
`np.percentile([1, 2, 3, 4, 5, 6], 50, interpolation="nearest")`
returns 3

This will also avoid a `ValueError `in method `to_datetime64`, line 449, where conversion to datetime64 is only possible with year as an integer.