### PR TITLE
Update codecov uploader

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -43,7 +43,7 @@ jobs:
           coverage xml
 
       - name: Upload unittest coverage
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v2
         with:
           file: ./coverage.xml
           env_vars: OS,PYTHON_VERSION


### PR DESCRIPTION
Switch to version 2 of the codecov uploader since version 1 is deprecated and will be turned off in Feb. 2022