### PR TITLE
Fix calibration when 3b is totally deactivated

### DIFF
--- a/pygac/klm_reader.py
+++ b/pygac/klm_reader.py
@@ -800,6 +800,12 @@ class KLMReader(Reader):
         """
         return self.scans["scan_line_bit_field"][:] & 3
 
+    def _get_ir_channels_to_calibrate(self):
+        ir_channels_to_calibrate = [3, 4, 5]
+        if np.all(self.get_ch3_switch() != 0):
+            ir_channels_to_calibrate = [4, 5]
+        return ir_channels_to_calibrate
+
     def postproc(self, channels):
         """Apply KLM specific postprocessing.
 

--- a/pygac/klm_reader.py
+++ b/pygac/klm_reader.py
@@ -66,7 +66,6 @@ class KLM_QualityIndicator(IntFlag):
       post-January 25, 2006, all spacecraft).
 
     Notes:
-
     - Table 8.3.1.3.3.1-1. and Table 8.3.1.4.3.1-1. define bit: 21 as
       "frame sync word not valid"
     - Table 8.3.1.3.3.2-1. and Table 8.3.1.4.3.2-1. define bit: 21 as
@@ -103,7 +102,7 @@ class KLM_QualityIndicator(IntFlag):
     PSEUDO_NOISE = 2**0  # Pseudo noise occurred on this frame
 
 
-# GAC header object
+# header object
 
 header = np.dtype([("data_set_creation_site_id", "S3"),
                    ("ascii_blank_=_x20", "S1"),
@@ -721,7 +720,7 @@ class KLMReader(Reader):
 
     @classmethod
     def _validate_header(cls, header):
-        """Check if the header belongs to this reader"""
+        """Check if the header belongs to this reader."""
         # call super to enter the Method Resolution Order (MRO)
         super(KLMReader, cls)._validate_header(header)
         LOG.debug("validate header")
@@ -795,7 +794,7 @@ class KLMReader(Reader):
     def get_ch3_switch(self):
         """Channel 3 identification.
 
-        0: Channel 3b (Brightness temperature
+        0: Channel 3b (Brightness temperature)
         1: Channel 3a (Reflectance)
         2: Transition (No data)
         """
@@ -814,6 +813,7 @@ class KLMReader(Reader):
 
     def _adjust_clock_drift(self):
         """Adjust the geolocation to compensate for the clock error.
+
         Note:
             Clock drift correction is only applied to POD satellites.
             On the KLM series, the clock is updated daily.

--- a/pygac/pod_reader.py
+++ b/pygac/pod_reader.py
@@ -64,6 +64,7 @@ class POD_QualityIndicator(IntFlag):
     Source:
         POD guide Table 3.1.2.1-2. Format of quality indicators.
     """
+
     # POD guide Table 3.1.2.1-2. Format of quality indicators.
     FATAL_FLAG = 2**31  # Data should not be used for product generation
     TIME_ERROR = 2**30  # A time sequence error was detected while Processing
@@ -420,7 +421,7 @@ class PODReader(Reader):
         return self.decode_timestamps(self.scans["time_code"])
 
     def _compute_missing_lonlat(self, missed_utcs):
-        """compute lon lat values using pyorbital"""
+        """Compute lon lat values using pyorbital."""
         tic = datetime.datetime.now()
 
         scan_rate = datetime.timedelta(milliseconds=1/self.scan_freq).total_seconds()
@@ -560,6 +561,11 @@ class PODReader(Reader):
 
         return prt_counts, ict_counts, space_counts
 
+    @staticmethod
+    def _get_ir_channels_to_calibrate():
+        ir_channels_to_calibrate = [3, 4, 5]
+        return ir_channels_to_calibrate
+
     def postproc(self, channels):
         """No POD specific postprocessing to be done."""
         pass
@@ -573,7 +579,7 @@ class PODReader(Reader):
                            channels[:, :, 3], channels[:, :, 4])
 
     def _get_calibrated_channels_uniform_shape(self):
-        """Prepare the channels as input for gac_io.save_gac"""
+        """Prepare the channels as input for gac_io.save_gac."""
         _channels = self.get_calibrated_channels()
         # prepare input
         # maybe there is a better (less memory requiring) method

--- a/pygac/reader.py
+++ b/pygac/reader.py
@@ -27,7 +27,6 @@ Can't be used as is, has to be subclassed to add specific read functions.
 from abc import ABCMeta, abstractmethod
 import datetime
 import logging
-from contextlib import suppress
 
 import numpy as np
 import os
@@ -525,10 +524,7 @@ class Reader(six.with_metaclass(ABCMeta)):
         )
         prt, ict, space = self.get_telemetry()
 
-        ir_channels_to_calibrate = [3, 4, 5]
-        with suppress(AttributeError):
-            if np.all(self.get_ch3_switch() != 0):
-                ir_channels_to_calibrate = [4, 5]
+        ir_channels_to_calibrate = self._get_ir_channels_to_calibrate()
 
         for chan in ir_channels_to_calibrate:
             channels[:, :, chan - 6] = calibrate_thermal(

--- a/pygac/reader.py
+++ b/pygac/reader.py
@@ -27,6 +27,8 @@ Can't be used as is, has to be subclassed to add specific read functions.
 from abc import ABCMeta, abstractmethod
 import datetime
 import logging
+from contextlib import suppress
+
 import numpy as np
 import os
 import re
@@ -522,7 +524,13 @@ class Reader(six.with_metaclass(ABCMeta)):
             corr
         )
         prt, ict, space = self.get_telemetry()
-        for chan in [3, 4, 5]:
+
+        ir_channels_to_calibrate = [3, 4, 5]
+        with suppress(AttributeError):
+            if np.all(self.get_ch3_switch() != 0):
+                ir_channels_to_calibrate = [4, 5]
+
+        for chan in ir_channels_to_calibrate:
             channels[:, :, chan - 6] = calibrate_thermal(
                 channels[:, :, chan - 6],
                 prt,

--- a/pygac/tests/test_reader.py
+++ b/pygac/tests/test_reader.py
@@ -21,9 +21,10 @@
 """Test the readers."""
 
 import datetime
-import unittest
-import sys
 import os
+import sys
+import unittest
+
 try:
     import mock
 except ImportError:
@@ -60,7 +61,7 @@ class FakeGACReader(GACReader):
 
     def __init__(self):
         """Initialize the fake reader."""
-        super(FakeGACReader, self).__init__()
+        super().__init__()
         self.scan_width = self.across_track
         scans = np.zeros(self.along_track, dtype=scanline)
         scans["scan_line_number"] = np.arange(self.along_track)

--- a/pygac/tests/test_reader.py
+++ b/pygac/tests/test_reader.py
@@ -93,6 +93,10 @@ class FakeGACReader(GACReader):
     def _get_lonlat(self):
         pass
 
+    @staticmethod
+    def _get_ir_channels_to_calibrate():
+        return [3, 4, 5]
+
     def postproc(self, channels):
         """Postprocess the data."""
         pass


### PR DESCRIPTION
Fully deactivated 3b channel can crash the calibration. This PR fixes this.

This fixes #78 and fixes #22 in principle.