### PR TITLE
Don't use deprecated distutils module.

### DIFF
--- a/continuous_integration/environment.yaml
+++ b/continuous_integration/environment.yaml
@@ -8,6 +8,7 @@ dependencies:
   - python-dateutil
   - hdf5
   - h5py
+  - packaging
   - pytest
   - pytest-cov
   - pip

--- a/pygac/reader.py
+++ b/pygac/reader.py
@@ -43,7 +43,7 @@ from pyorbital.orbital import Orbital
 from pyorbital import astronomy
 from pygac.calibration import Calibrator, calibrate_solar, calibrate_thermal
 from pygac import gac_io
-from distutils.version import LooseVersion
+from packaging.version import Version
 
 LOG = logging.getLogger(__name__)
 
@@ -770,7 +770,7 @@ class Reader(six.with_metaclass(ABCMeta)):
             self.lons, self.lats, 0)
         # Sometimes (pyorbital <= 1.6.1) the get_observer_look_not_tle returns nodata instead of 90.
         # Problem solved with https://github.com/pytroll/pyorbital/pull/77
-        if LooseVersion(pyorbital.__version__) <= LooseVersion('1.6.1'):
+        if Version(pyorbital.__version__) <= Version('1.6.1'):
             sat_elev[:, mid_column] = 90
         return sat_azi, sat_elev
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,6 @@ numpy>=1.6.1
 h5py>=2.0.1
 scipy>=0.8.0
 python-geotiepoints>=1.1.8
+packaging>=14.0
 
 


### PR DESCRIPTION
`pygac/reader.py` still uses the deprecated distutils which will be removed in Python 3.12.

From [What’s New In Python 3.10](https://docs.python.org/3/whatsnew/3.10.html#distutils-deprecated):
> The entire `distutils` package is deprecated, to be removed in Python 3.12. Its functionality for specifying package builds has already been completely replaced by third-party packages `setuptools` and `packaging`, and most other commonly used APIs are available elsewhere in the standard library (such as [`platform`](https://docs.python.org/3/library/platform.html#module-platform), [`shutil`](https://docs.python.org/3/library/shutil.html#module-shutil), [`subprocess`](https://docs.python.org/3/library/subprocess.html#module-subprocess) or [`sysconfig`](https://docs.python.org/3/library/sysconfig.html#module-sysconfig)). There are no plans to migrate any other functionality from distutils, and applications that are using other functions should plan to make private copies of the code. Refer to [PEP 632](https://peps.python.org/pep-0632/) for discussion.

[Porting from Distutils](https://setuptools.pypa.io/en/latest/deprecated/distutils-legacy.html#prefer-setuptools) suggests using [`packaging.version`](https://packaging.pypa.io/en/latest/version.html) instead of `distutils.version`.