### PR TITLE
Enable decoding of tbm dataset name

### DIFF
--- a/pygac/pod_reader.py
+++ b/pygac/pod_reader.py
@@ -51,7 +51,7 @@ from pyorbital.geoloc_instrument_definitions import avhrr_gac
 
 from pygac.clock_offsets_converter import get_offsets
 from pygac.correct_tsm_issue import TSM_AFFECTED_INTERVALS_POD, get_tsm_idx
-from pygac.reader import NoTLEData, Reader, ReaderError
+from pygac.reader import DecodingError, NoTLEData, Reader, ReaderError
 from pygac.slerp import slerp
 from pygac.utils import file_opener
 
@@ -321,24 +321,14 @@ class PODReader(Reader):
             _tbm_head, = np.frombuffer(
                 fd_.read(tbm_header.itemsize),
                 dtype=tbm_header, count=1)
-            for encoding in ("utf-8", "cp500"):
-                try:
-                    data_set_name = _tbm_head['data_set_name'].decode(encoding)
-                except ValueError:
-                    continue
-                else:
-                    break
-            else:
-                data_set_name = '---'
-            allowed_empty = (42*b'\x00' + b'  ')
-            if (cls.data_set_pattern.match(data_set_name)
-                    or (_tbm_head['data_set_name'] == allowed_empty)):
-                tbm_head = _tbm_head.copy()
+            try:
+                tbm_head = cls._validate_tbm_header(_tbm_head)
                 tbm_offset = tbm_header.itemsize
-            else:
-                fd_.seek(0)
+            except DecodingError:
                 tbm_head = None
                 tbm_offset = 0
+
+            fd_.seek(tbm_offset, 0)
             header = cls.choose_header_based_on_timestamp(header_date, fd_)
             fd_.seek(tbm_offset, 0)
             # need to copy frombuffer to have write access on head
@@ -348,6 +338,18 @@ class PODReader(Reader):
         head = cls._correct_data_set_name(head, filename)
         cls._validate_header(head)
         return tbm_head, head
+
+    @classmethod
+    def _validate_tbm_header(cls, potential_tbm_header):
+        data_set_name = potential_tbm_header['data_set_name']
+        allowed_empty = (42*b'\x00' + b'  ')
+        if data_set_name == allowed_empty:
+            return potential_tbm_header.copy()
+
+        # This will raise a DecodingError if the data_set_name is not valid.
+        cls._decode_data_set_name(data_set_name)
+        return potential_tbm_header.copy()
+
 
     @classmethod
     def choose_header_based_on_timestamp(cls, header_date, fd_):

--- a/pygac/reader.py
+++ b/pygac/reader.py
@@ -209,16 +209,10 @@ class Reader(six.with_metaclass(ABCMeta)):
             filename (str): path to file
         """
         filename = str(filename)
-        for encoding in "utf-8", "cp500":
-            data_set_name = header['data_set_name']
-            try:
-                data_set_name = cls._decode_data_set_name(data_set_name, encoding)
-            except DecodingError as err:
-                LOG.debug(str(err))
-            else:
-                header["data_set_name"] = data_set_name
-                break
-        else:
+        data_set_name = header['data_set_name']
+        try:
+            header["data_set_name"] = cls._decode_data_set_name(data_set_name)
+        except DecodingError:
             LOG.debug(f'The data_set_name in header {header["data_set_name"]} does not match.'
                       ' Use filename instead.')
             match = cls.data_set_pattern.search(filename)
@@ -232,7 +226,19 @@ class Reader(six.with_metaclass(ABCMeta)):
         return header
 
     @classmethod
-    def _decode_data_set_name(cls, data_set_name, encoding):
+    def _decode_data_set_name(cls, data_set_name):
+        for encoding in "utf-8", "cp500":
+            try:
+                data_set_name = cls._decode_data_set_name_for_encoding(data_set_name, encoding)
+            except DecodingError as err:
+                LOG.debug(str(err))
+            else:
+                return data_set_name
+        else:
+            raise DecodingError("Could not reliably decode the dataset name.")
+
+    @classmethod
+    def _decode_data_set_name_for_encoding(cls, data_set_name, encoding):
         data_set_name = data_set_name.decode(encoding, errors='ignore')
         if not cls.data_set_pattern.match(data_set_name):
             raise DecodingError(f'The data_set_name in header {data_set_name} '

--- a/pygac/tests/test_reader.py
+++ b/pygac/tests/test_reader.py
@@ -24,20 +24,20 @@ import datetime
 import os
 import sys
 import unittest
-import pytest
-
 from unittest import mock
+
 import numpy as np
 import numpy.testing
-from pygac.gac_reader import GACReader, ReaderError
-from pygac.lac_reader import LACReader
-from pygac.pod_reader import POD_QualityIndicator
-from pygac.gac_pod import scanline
-from pygac.reader import NoTLEData
-from pygac.lac_pod import LACPODReader
+import pytest
 
-from pygac.pod_reader import tbm_header as tbm_header_dtype, header3
+from pygac.gac_pod import scanline
+from pygac.gac_reader import GACReader, ReaderError
+from pygac.lac_pod import LACPODReader
 from pygac.lac_pod import scanline as lacpod_scanline
+from pygac.lac_reader import LACReader
+from pygac.pod_reader import POD_QualityIndicator, header3
+from pygac.pod_reader import tbm_header as tbm_header_dtype
+from pygac.reader import NoTLEData
 
 
 class TestPath(os.PathLike):
@@ -688,7 +688,7 @@ def pod_file_with_tbm_header(tmp_path):
     number_of_scans = 3
 
     tbm_header = np.zeros(1, dtype=tbm_header_dtype)
-    tbm_header["data_set_name"] = b"BRN.HRPT.NJ.D00322.S0334.E0319.B3031919.BL  "
+    tbm_header["data_set_name"] = "BRN.HRPT.NJ.D00322.S0334.E0319.B3031919.BL\x80\x80".encode("cp500")
     tbm_header["select_flag"] = b"S"
     tbm_header["beginning_latitude"] = b"+77"
     tbm_header["ending_latitude"] = b"+22"


### PR DESCRIPTION
This PR fixes the reading of dataset including TBM headers (POD files) which have cp500-(EBCDIC)-encoded dataset name field.

This fixes https://github.com/pytroll/pygac/issues/130