### PR TITLE
Fix number of scalines read from GAC POD files

### DIFF
--- a/pygac/gac_pod.py
+++ b/pygac/gac_pod.py
@@ -64,6 +64,12 @@ class GACPODReader(GACReader, PODReader):
         """Init the GAC POD reader."""
         GACReader.__init__(self, *args, **kwargs)
         self.scanline_type = scanline
+        # GAC POD files were originally written to tapes using 6440 byte physical records
+        # with two 3220 logical records per physical record. As the header is in the first
+        # physical record the scanline data will start at offset 6440 in the filestream.
+        # This means the second logical record (at offset 3220) is not used and contains
+        # junk / padding data. The data often appears to be a valid scanline, but it is a
+        # duplicate of a data appearing later in the file and should not be used.
         self.offset = 6440
         self.scan_points = np.arange(3.5, 2048, 5)
 

--- a/pygac/gac_pod.py
+++ b/pygac/gac_pod.py
@@ -64,7 +64,7 @@ class GACPODReader(GACReader, PODReader):
         """Init the GAC POD reader."""
         GACReader.__init__(self, *args, **kwargs)
         self.scanline_type = scanline
-        self.offset = 3220
+        self.offset = 6440
         self.scan_points = np.arange(3.5, 2048, 5)
 
 

--- a/pygac/klm_reader.py
+++ b/pygac/klm_reader.py
@@ -685,7 +685,8 @@ class KLMReader(Reader):
             buffer = fd_.read()
             count = self.head["count_of_data_records"]
             self._read_scanlines(buffer, count)
-        self.correct_scan_line_numbers()
+        if self.correct_scanlines:
+            self.correct_scan_line_numbers()
         self.spacecraft_id = self.head["noaa_spacecraft_identification_code"]
         self.spacecraft_name = self.spacecraft_names[self.spacecraft_id]
 

--- a/pygac/pod_reader.py
+++ b/pygac/pod_reader.py
@@ -38,6 +38,7 @@ Format specification can be found in chapters 2 & 3 of the `POD user guide`_.
 
 import datetime
 import logging
+import warnings
 
 try:
     from enum import IntFlag
@@ -288,15 +289,8 @@ class PODReader(Reader):
             # read scan lines until end of file
             fd_.seek(self.offset + tbm_offset, 0)
             buffer = fd_.read()
+            buffer = self._truncate_padding_record(buffer)
             count = self.head["number_of_scans"]
-            # check if we have 2 scanlines per physical record
-            if self.offset // self.scanline_type.itemsize == 2:
-                # expect a half record of padding for an odd number of scanlines
-                rec_count = len(buffer) // self.scanline_type.itemsize
-                if rec_count % 2 == 1:
-                    LOG.warning("Unexpected record length for POD file")
-                if count % 2 == 1 and rec_count == count+1:
-                    buffer = buffer[:-self.scanline_type.itemsize]
             self._read_scanlines(buffer, count)
         year, jday, _ = self.decode_timestamps(self.head["start_time"])
         start_date = (datetime.date(year, 1, 1) +
@@ -310,6 +304,36 @@ class PODReader(Reader):
         LOG.info(
             "Reading %s data", self.spacecrafts_orbital[self.spacecraft_id])
         return self.head, self.scans
+
+    def _truncate_padding_record(self, buffer):
+        """Remove the padding record (if present) from the data stream.
+
+        In POD files each scanline was stored as a "logical" record, and these
+        were written to the tapes in "physical" records. In the case of GAC
+        data there were two logical records (scanlines) per physical record,
+        so an odd number of scanlines would result in the final physical record
+        containing only one scanline and one "logical" record of padding.
+        """
+        scanlines_per_record = self.offset // self.scanline_type.itemsize
+        assert scanlines_per_record in [1,2]
+        # Do nothing if the logical and physical records are the same size (LAC).
+        if scanlines_per_record == 1:
+            return buffer
+        # File should contain an integer number of physical records
+        n_logical = len(buffer) // self.scanline_type.itemsize
+        if n_logical % scanlines_per_record != 0:
+            LOG.warning("Unexpected record length for POD file (incomplete physical record?)")
+            warnings.warn("Incomplete POD physical record",
+                          category=RuntimeWarning, stacklevel=2)
+        # How many physical / logical records do we expect based on the file header?
+        expected_scanlines = self.head["number_of_scans"]
+        expected_physical = (expected_scanlines + scanlines_per_record - 1) // scanlines_per_record
+        expected_logical = expected_physical * scanlines_per_record
+        # Only trim the padding if the file is the expected size, so any unexpected
+        # cases will still be dealt with in _read_scanlines
+        if n_logical == expected_logical and n_logical > expected_scanlines:
+            buffer = buffer[:expected_scanlines * self.scanline_type.itemsize]
+        return buffer
 
     @classmethod
     def read_header(cls, filename, fileobj=None, header_date="auto"):

--- a/pygac/pod_reader.py
+++ b/pygac/pod_reader.py
@@ -315,7 +315,6 @@ class PODReader(Reader):
         containing only one scanline and one "logical" record of padding.
         """
         scanlines_per_record = self.offset // self.scanline_type.itemsize
-        assert scanlines_per_record in [1,2], f"POD files should have 1 or 2 logical records per physical, not {scanlines_per_record}"
         # Do nothing if the logical and physical records are the same size (LAC).
         if scanlines_per_record == 1:
             return buffer

--- a/pygac/pod_reader.py
+++ b/pygac/pod_reader.py
@@ -314,8 +314,8 @@ class PODReader(Reader):
         so an odd number of scanlines would result in the final physical record
         containing only one scanline and one "logical" record of padding.
         """
-        scanlines_per_record = self.offset // self.scanline_type.itemsize
-        assert scanlines_per_record in [1,2]
+        scanlines_per_record = 1+ self.offset // self.scanline_type.itemsize
+        assert scanlines_per_record in [1,2], f"POD files should have 1 or 2 logical records per physical, not {scanlines_per_record}"
         # Do nothing if the logical and physical records are the same size (LAC).
         if scanlines_per_record == 1:
             return buffer
@@ -323,7 +323,7 @@ class PODReader(Reader):
         n_logical = len(buffer) // self.scanline_type.itemsize
         if n_logical % scanlines_per_record != 0:
             LOG.warning("Unexpected record length for POD file (incomplete physical record?)")
-            warnings.warn("Incomplete POD physical record",
+            warnings.warn("Unexpected record length for POD file (incomplete physical record?)",
                           category=RuntimeWarning, stacklevel=2)
         # How many physical / logical records do we expect based on the file header?
         expected_scanlines = self.head["number_of_scans"]

--- a/pygac/pod_reader.py
+++ b/pygac/pod_reader.py
@@ -314,7 +314,7 @@ class PODReader(Reader):
         so an odd number of scanlines would result in the final physical record
         containing only one scanline and one "logical" record of padding.
         """
-        scanlines_per_record = 1+ self.offset // self.scanline_type.itemsize
+        scanlines_per_record = self.offset // self.scanline_type.itemsize
         assert scanlines_per_record in [1,2], f"POD files should have 1 or 2 logical records per physical, not {scanlines_per_record}"
         # Do nothing if the logical and physical records are the same size (LAC).
         if scanlines_per_record == 1:

--- a/pygac/reader.py
+++ b/pygac/reader.py
@@ -103,7 +103,8 @@ class Reader(ABC):
     def __init__(self, interpolate_coords=True, adjust_clock_drift=True,
                  tle_dir=None, tle_name=None, tle_thresh=7, creation_site=None,
                  custom_calibration=None, calibration_file=None, header_date="auto",
-                 calibration_method="noaa", calibration_parameters=None):
+                 calibration_method="noaa", calibration_parameters=None,
+                 correct_scanlines=True):
         """Init the reader.
 
         Args:
@@ -120,6 +121,7 @@ class Reader(ABC):
                                 calibration coefficients
             calibration_file: path to json file containing default calibrations
             header_date: the date to use for pod header choice. Defaults to "auto".
+            correct_scanlines: Remove corrrupt scanline numbers
 
         """
         self.meta_data = {}
@@ -130,6 +132,7 @@ class Reader(ABC):
         self.tle_thresh = tle_thresh
         self.creation_site = (creation_site or "NSS").encode("utf-8")
         self.header_date = header_date
+        self.correct_scanlines = correct_scanlines
         self.head = None
         self.scans = None
         self.spacecraft_name = None

--- a/pygac/reader.py
+++ b/pygac/reader.py
@@ -121,7 +121,7 @@ class Reader(ABC):
                                 calibration coefficients
             calibration_file: path to json file containing default calibrations
             header_date: the date to use for pod header choice. Defaults to "auto".
-            correct_scanlines: Remove corrrupt scanline numbers
+            correct_scanlines: Remove corrrupt scanline numbers. Defaults to True
 
         """
         self.meta_data = {}

--- a/pygac/tests/test_pod.py
+++ b/pygac/tests/test_pod.py
@@ -292,28 +292,70 @@ class TestPOD(unittest.TestCase):
         get_tle_lines.side_effect = NoTLEData("No TLE data available")
         reader._adjust_clock_drift()  # should pass without errors
 
-    def test__truncate_padding_record(self):
+
+class TestPOD_truncate(unittest.TestCase):
+    """Test the POD GAC reader."""
+
+    longMessage = True
+
+    def setUp(self):
+        """Set up the test."""
+        self.reader = GACPODReader()
+        # python 2 compatibility
+        if sys.version_info.major < 3:
+            self.assertRaisesRegex = self.assertRaisesRegexp
+
+    def test__two_logical_record(self):
         """Test that truncate_padding_record is correctly dropping end padding"""
         reader = self.reader
         # GAC POD should have two logical records per physical
         self.assertEqual(reader.offset // reader.scanline_type.itemsize, 2)
+
+    def test__truncate_padding_record_even_correct(self):
+        """Test that truncate_padding_record is correctly dropping end padding"""
         # Even number of scans, correct file length
+        reader = self.reader
         reader.head = {'number_of_scans': 10}
         buffer = reader._truncate_padding_record(bytes(10*3220))
         self.assertEqual(len(buffer), 10*3220)
+
+
+    def test__truncate_padding_record_odd_correct(self):
+        """Test that truncate_padding_record is correctly dropping end padding"""
+        # Even number of scans, correct file length
+        reader = self.reader
         # Odd number of scans, correct file length (should truncate)
         reader.head = {'number_of_scans': 9}
         buffer = reader._truncate_padding_record(bytes(10*3220))
         self.assertEqual(len(buffer), 9*3220)
+
+
+    def test__truncate_padding_record_odd_nopadding(self):
+        """Test that truncate_padding_record is correctly dropping end padding"""
+        # Even number of scans, correct file length
+        reader = self.reader
+
         # Odd number of scans, padding record is missing
-        with self.assertWarnsRegex(RuntimeWarning, "Incomplete POD physical record"):
+        with self.assertWarnsRegex(RuntimeWarning, "incomplete physical record"):
             reader.head = {'number_of_scans': 9}
             buffer = reader._truncate_padding_record(bytes(9*3220))
             self.assertEqual(len(buffer), 9*3220)
+
+    def test__truncate_padding_record_shortfile(self):
+        """Test that truncate_padding_record is correctly dropping end padding"""
+        # Even number of scans, correct file length
+        reader = self.reader
+
         # File is too short (should do nothing)
         reader.head = {'number_of_scans': 9}
         buffer = reader._truncate_padding_record(bytes(8*3220))
         self.assertEqual(len(buffer), 8*3220)
+
+    def test__truncate_padding_record_longfile(self):
+        """Test that truncate_padding_record is correctly dropping end padding"""
+        # Even number of scans, correct file length
+        reader = self.reader
+
         # File is too long (should do nothing)
         reader.head = {'number_of_scans': 9}
         buffer = reader._truncate_padding_record(bytes(12*3220))

--- a/pygac/tests/test_pod.py
+++ b/pygac/tests/test_pod.py
@@ -301,9 +301,6 @@ class TestPOD_truncate(unittest.TestCase):
     def setUp(self):
         """Set up the test."""
         self.reader = GACPODReader()
-        # python 2 compatibility
-        if sys.version_info.major < 3:
-            self.assertRaisesRegex = self.assertRaisesRegexp
 
     def test__two_logical_record(self):
         """Test that truncate_padding_record is correctly dropping end padding"""


### PR DESCRIPTION
Fixes #136 by changing the gac_pod offset, plus some changes made for investigating:

* Added an option to disable call to correct_scan_line_numbers
* Updates pod version of `correct_scan_line_numbers` to return results from base class
* Adds code to discard the final scanline if we have:
  * two logical records per physical record (i.e. gac data)
  * an odd number of expected scanlines and actual length is exactly n+1 lines

Note - the final check is currently only discarding the _expected_ padding at the end of a file. It will still read any unexpected padding and attempt to parse as scanlines. For production use it would probably be better to only read `self.head["number_of_scans"]` scanlines.