### PR TITLE
Use new avhrr*_from_times definitions to calculate tie-point locations

### DIFF
--- a/pygac/gac_reader.py
+++ b/pygac/gac_reader.py
@@ -27,6 +27,16 @@ Can't be used as is, has to be subclassed to add specific read functions.
 """
 
 import logging
+import warnings
+
+try:
+    from pyorbital.geoloc_instrument_definitions import avhrr_gac_from_times
+except ImportError:
+    # In pyorbital 1.9.2 and earlier avhrr_gac returned LAC geometry
+    from pyorbital.geoloc_instrument_definitions import avhrr_gac as avhrr_gac_from_times
+    warnings.warn('pyorbital version does not support avhrr_gac_from_times. ' +
+                  'Computation of missing longitude/latitudes will be incorrect.')
+
 
 import pygac.pygac_geotiepoints as gtp
 from pygac.pygac_geotiepoints import GAC_LONLAT_SAMPLE_POINTS
@@ -49,6 +59,7 @@ class GACReader(Reader):
         super().__init__(*args, **kwargs)
         self.scan_width = 409
         self.lonlat_interpolator = gtp.gac_lat_lon_interpolator
+        self.geoloc_definition = avhrr_gac_from_times
 
     @classmethod
     def _validate_header(cls, header):

--- a/pygac/gac_reader.py
+++ b/pygac/gac_reader.py
@@ -33,9 +33,11 @@ try:
     from pyorbital.geoloc_instrument_definitions import avhrr_gac_from_times
 except ImportError:
     # In pyorbital 1.9.2 and earlier avhrr_gac returned LAC geometry
-    from pyorbital.geoloc_instrument_definitions import avhrr_gac as avhrr_gac_from_times
+    from pyorbital.geoloc_instrument_definitions import avhrr_gac
+    def avhrr_gac_from_times(times, points):
+        return avhrr_gac(times, points*5+3.5)
     warnings.warn('pyorbital version does not support avhrr_gac_from_times. ' +
-                  'Computation of missing longitude/latitudes will be incorrect.')
+                  'Computation of missing longitude/latitudes may be incorrect.')
 
 
 import pygac.pygac_geotiepoints as gtp

--- a/pygac/lac_reader.py
+++ b/pygac/lac_reader.py
@@ -26,6 +26,12 @@
 
 import logging
 
+try:
+    from pyorbital.geoloc_instrument_definitions import avhrr_from_times
+except ImportError:
+    # In pyorbital 1.9.2 and earlier avhrr_gac returned LAC geometry
+    from pyorbital.geoloc_instrument_definitions import avhrr_gac as avhrr_from_times
+
 import pygac.pygac_geotiepoints as gtp
 from pygac.pygac_geotiepoints import LAC_LONLAT_SAMPLE_POINTS
 from pygac.reader import Reader, ReaderError
@@ -47,6 +53,7 @@ class LACReader(Reader):
         super(LACReader, self).__init__(*args, **kwargs)
         self.scan_width = 2048
         self.lonlat_interpolator = gtp.lac_lat_lon_interpolator
+        self.geoloc_definition = avhrr_from_times
 
     @classmethod
     def _validate_header(cls, header):

--- a/pygac/tests/test_pod.py
+++ b/pygac/tests/test_pod.py
@@ -186,10 +186,10 @@ class TestPOD(unittest.TestCase):
             expected_mask
         )
 
-    @mock.patch("pygac.pod_reader.get_lonlatalt")
-    @mock.patch("pygac.pod_reader.compute_pixels")
+    @mock.patch("pygac.reader.get_lonlatalt")
+    @mock.patch("pygac.reader.compute_pixels")
     @mock.patch("pygac.reader.Reader.get_tle_lines")
-    @mock.patch("pygac.pod_reader.avhrr_gac")
+    @mock.patch("pygac.gac_reader.avhrr_gac_from_times")
     def test__adjust_clock_drift(self, avhrr_gac, get_tle_lines,
                                  compute_pixels, get_lonlatalt):
         """Test the clock drift adjustment."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ dependencies = [
     "docutils>=0.3",
     "h5py>=2.0.1",
     "numpy>=1.8.0",
-    "pyorbital>=0.3.2",
+    "pyorbital>=1.10.0",
     "python-geotiepoints>=1.1.8",
     "scipy>=0.8.0",
     "packaging",


### PR DESCRIPTION
Updates pygac to use the new avhrr instrument definitions (see pytroll/pyorbital#185) in pyorbital 1.10. Fixed #139

The geoloc instrument definition is now stored in the reader object (as `geoloc_definition`) so we can select the appropriate function in gac / lac reader (and allows fallback for earlier version of pyorbital)

`_compute_missing_lonlat` is moved from pod_reader to reader.py as this will allow us to compute lon/lat coordinates for KLM sensors (and investigate #140)