### PR TITLE
Allow user to control tie-point offset for lon/lat interpolation

### DIFF
--- a/pygac/gac_reader.py
+++ b/pygac/gac_reader.py
@@ -40,7 +40,6 @@ except ImportError:
                   'Computation of missing longitude/latitudes may be incorrect.')
 
 
-import pygac.pygac_geotiepoints as gtp
 from pygac.pygac_geotiepoints import GAC_LONLAT_SAMPLE_POINTS
 from pygac.reader import Reader, ReaderError
 
@@ -60,7 +59,6 @@ class GACReader(Reader):
         """Init the GAC reader."""
         super().__init__(*args, **kwargs)
         self.scan_width = 409
-        self.lonlat_interpolator = gtp.gac_lat_lon_interpolator
         self.geoloc_definition = avhrr_gac_from_times
 
     @classmethod

--- a/pygac/lac_reader.py
+++ b/pygac/lac_reader.py
@@ -32,7 +32,6 @@ except ImportError:
     # In pyorbital 1.9.2 and earlier avhrr_gac returned LAC geometry
     from pyorbital.geoloc_instrument_definitions import avhrr_gac as avhrr_from_times
 
-import pygac.pygac_geotiepoints as gtp
 from pygac.pygac_geotiepoints import LAC_LONLAT_SAMPLE_POINTS
 from pygac.reader import Reader, ReaderError
 
@@ -52,7 +51,6 @@ class LACReader(Reader):
         """Init the LAC reader."""
         super(LACReader, self).__init__(*args, **kwargs)
         self.scan_width = 2048
-        self.lonlat_interpolator = gtp.lac_lat_lon_interpolator
         self.geoloc_definition = avhrr_from_times
 
     @classmethod

--- a/pygac/reader.py
+++ b/pygac/reader.py
@@ -34,6 +34,7 @@ from abc import ABC, abstractmethod
 from contextlib import suppress
 from importlib.metadata import entry_points
 
+import geotiepoints as gtp
 import numpy as np
 import pyorbital
 import xarray as xr
@@ -656,6 +657,31 @@ class Reader(ABC):
     def get_telemetry(self):  # pragma: no cover
         """KLM/POD specific readout of telemetry."""
         raise NotImplementedError
+
+    def lonlat_interpolator(self, lons, lats):
+        """Interpolate from lat-lon tie-points to pixel locations
+
+        Args:
+            lons: Longitude tie-points
+            lats: Latitude tie-points
+
+        Returns:
+            pixel_longitudes, pixel_latitudes
+        """
+        cols_subset = self.lonlat_sample_points
+        cols_full = np.arange(self.scan_width)
+        rows = np.arange(len(lats))
+
+        along_track_order = 1
+        cross_track_order = 3
+
+        satint = gtp.SatelliteInterpolator((lons, lats),
+                                           (rows, cols_subset),
+                                           (rows, cols_full),
+                                           along_track_order,
+                                           cross_track_order)
+
+        return satint.interpolate()
 
     def get_lonlat(self):
         """Compute lat/lon coordinates.


### PR DESCRIPTION
Currently it is tricky to address #88 as the lat lon interpolators are defined as functions in `pygac_geotiepoints` which use fixed tie-points defined in that module. I propose we change `lonlat_interpolator` to a method of the Reader class which means:
* We can use the `self.lonlat_sample_points` as the tie-point locations
* No longer need separate gac and lac versions as the Reader object is already storing the tie-points and number of pixels

Is this approach acceptable?

If so I will:
* Remove `pygac_geotiepoints.py`
* Set the tie-point locations in the appropriate Reader e.g. GACKLMReader would set `lonlat_sample_points = np.arange(4.5, 405, 8)`