### PR TITLE
Fix python requirement in rtd

### DIFF
--- a/doc/rtd_environment.yaml
+++ b/doc/rtd_environment.yaml
@@ -2,7 +2,6 @@ name: readthedocs
 channels:
   - conda-forge
 dependencies:
-  - python=3.9
   - numpy
   - scipy
   - bottleneck


### PR DESCRIPTION
An old python version was required, now it should be free.