### PR TITLE
Add first guess for time offset

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -91,7 +91,7 @@ pygments_style = "sphinx"
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-html_theme = "default"
+html_theme = "sphinx_rtd_theme"
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the

--- a/pygac/klm_reader.py
+++ b/pygac/klm_reader.py
@@ -36,12 +36,7 @@ Format specification can be found in section 8 of the `KLM user guide`_.
 
 import datetime
 import logging
-
-try:
-    from enum import IntFlag
-except ImportError:
-    # python version < 3.6, use a simple object without nice representation
-    IntFlag = object
+from enum import IntFlag
 
 import numpy as np
 

--- a/pygac/pod_reader.py
+++ b/pygac/pod_reader.py
@@ -39,12 +39,7 @@ Format specification can be found in chapters 2 & 3 of the `POD user guide`_.
 import datetime
 import logging
 import warnings
-
-try:
-    from enum import IntFlag
-except ImportError:
-    # python version < 3.6, use a simple object without nice representation
-    IntFlag = object
+from enum import IntFlag
 
 import numpy as np
 

--- a/pygac/reader.py
+++ b/pygac/reader.py
@@ -733,12 +733,43 @@ class Reader(ABC):
         return calibrated_ds
 
     def _georeference_data(self, calibrated_ds):
+        if not self.adjust_clock_drift:
+            thinned_lons, thinned_lats = self._get_lonlat_from_file()
+            gcps = np.array(((0, self.lonlat_sample_points[0]),
+                    (0, self.lonlat_sample_points[-1]),
+                    (len(self.scans) - 1, self.lonlat_sample_points[0]),
+                    (len(self.scans) - 1, self.lonlat_sample_points[-1])))
+            ref_lons = (thinned_lons[0, 0],
+                        thinned_lons[0, -1],
+                        thinned_lons[-1, 0],
+                        thinned_lons[-1, -1])
+            ref_lats = (thinned_lats[0, 0],
+                        thinned_lats[0, -1],
+                        thinned_lats[-1, 0],
+                        thinned_lats[-1, -1])
+            from pyorbital.geoloc_avhrr import estimate_time_offset
+            time_diff, _ = estimate_time_offset(gcps, ref_lons, ref_lats,
+                calibrated_ds["times"][0].values,
+                calibrated_ds.attrs["tle"],
+                calibrated_ds.attrs["max_scan_angle"])
+            time_diff = np.timedelta64(int(time_diff * 1e9), "ns")
+            lons, lats = self._compute_lonlats(time_offset=time_diff)
+            self._times_as_np_datetime64 += time_diff
+
+            calibrated_ds["longitude"].data = lons
+            calibrated_ds["latitude"].data = lats
+            calibrated_ds["times"].data = self._times_as_np_datetime64
+
         from georeferencer.georeferencer import get_swath_displacement
         _, _, _, sun_zen, _ = self.get_angles()
-        time_diff, roll, pitch, yaw = get_swath_displacement(calibrated_ds, sun_zen, self.reference_image)
+        time_diff, (roll, pitch, yaw), (odistances, mdistances) = get_swath_displacement(calibrated_ds, sun_zen,
+                                                                                         self.reference_image)
+        if np.median(mdistances) > 5000:
+            raise RuntimeError("Displacement minimization did not produce convincing improvements")
         self._rpy = roll, pitch, yaw
         time_diff = np.timedelta64(int(time_diff * 1e9), "ns")
         lons, lats = self._compute_lonlats(time_offset=time_diff)
+        self._times_as_np_datetime64 += time_diff
         calibrated_ds["longitude"].data = lons
         calibrated_ds["latitude"].data = lats
         calibrated_ds["times"].data = self._times_as_np_datetime64


### PR DESCRIPTION
This PR adds the possibility to make a first guess about the time offset, ie the time discrepency between the advertise scan line times and the navigation provided with the file.

We noticed that is some occasions, the scanline times would be quite bad and navigating with these and the tles would lead to large errors in navigation. At the same time, the lons and lats provided in the file, even if not perfect, would still give us the possibility to adjust the scan times for the better.

This is done in the case of georeferencing, when clock drift adjustment is set to false. 